### PR TITLE
ci: use native arm64 runner for aarch64 wheel builds

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -56,23 +56,19 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             artifact_name: wheels-linux-x86_64
+            runner: blacksmith-4vcpu-ubuntu-2404
           - target: aarch64-unknown-linux-gnu
             artifact_name: wheels-linux-aarch64
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
           command: build
           args: --release -i python3.11 -o dist --compatibility manylinux2014
-          docker-options: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '--platform linux/arm64' || '' }}
       - name: Verify Linux abi3 wheel
         run: |
           ls -1 dist

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,23 +17,19 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             artifact_name: wheels-linux-x86_64
+            runner: blacksmith-4vcpu-ubuntu-2404
           - target: aarch64-unknown-linux-gnu
             artifact_name: wheels-linux-aarch64
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
           command: build
           args: --release -i python3.11 -o dist --compatibility manylinux2014
-          docker-options: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '--platform linux/arm64' || '' }}
       - name: Verify Linux abi3 wheel
         run: |
           ls -1 dist


### PR DESCRIPTION
## Summary
- Use GitHub's `ubuntu-24.04-arm` runner for aarch64 builds instead of QEMU/cross-compilation
- `ring` crate requires native ARM toolchain - cross-compilation from x86 fails on ARM assembly
- Keeps `blacksmith-4vcpu-ubuntu-2404` for x86_64 builds

## Previous attempts
- #193: Added aarch64 target (cross-compile failed: ring assembly error)
- #194: Added QEMU setup (still cross-compiled, same error)
- #195: Added `--platform linux/arm64` docker option (maturin ignored it, same error)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/synth-laboratories/synth-ai/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
