### PR TITLE
[codex] Enable synth-ai release-candidate CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI workflow for pull requests and pushes to main branches.
+# CI workflow for pull requests, release-candidate pushes, and manual checks.
 # Runs lint, type check, tests, and validation checks in parallel.
 # Keep jobs in alphabetical order.
 
@@ -6,8 +6,9 @@ name: CI
 
 on:
   push:
-    branches: [main, nightly]
+    branches: [main, nightly, dev]
   pull_request:
+  workflow_dispatch:
 
 # Cancel in-progress runs on same branch/PR
 concurrency:

--- a/synth_ai/managed_research/models/runtime_image.py
+++ b/synth_ai/managed_research/models/runtime_image.py
@@ -268,9 +268,7 @@ class RuntimeImage:
         image_id = _coerce_actor_image_id(image_id_raw) if image_id_raw else None
         recipe_payload = payload.get("recipe")
         recipe = (
-            ImageRecipe.from_wire(recipe_payload)
-            if isinstance(recipe_payload, Mapping)
-            else None
+            ImageRecipe.from_wire(recipe_payload) if isinstance(recipe_payload, Mapping) else None
         )
         return cls(
             kind=kind,

--- a/synth_ai/managed_research/models/types.py
+++ b/synth_ai/managed_research/models/types.py
@@ -392,9 +392,7 @@ class KickoffContract:
             project_notes_framing=_optional_string(mapping, "project_notes_framing"),
             dispatch_requirements=_optional_object_dict(mapping.get("dispatch_requirements")),
             tasks=[_optional_object_dict(item) for item in task_payload],
-            plan_task_payloads=[
-                _optional_object_dict(item) for item in plan_task_payload
-            ],
+            plan_task_payloads=[_optional_object_dict(item) for item in plan_task_payload],
             task_briefs=_string_list(
                 mapping.get("task_briefs"),
                 label="kickoff contract.task_briefs",


### PR DESCRIPTION
## Summary
- run the existing synth-ai CI workflow on dev pushes
- add workflow_dispatch so a release-candidate SHA can be checked manually before PyPI publish
- keep existing job names and job bodies unchanged

## Launch context
Managed Research launch is blocked on checked release-SHA evidence for synth-ai==0.11.1. Current dev head has local package build/smoke proof, but no GitHub checks attached.

## Validation
- git diff --check -- .github/workflows/ci.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml_ok"'

No package tests or evals were run for this one-line workflow trigger change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/synth-laboratories/synth-ai/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->