### PR TITLE
Align package copy with current Synth surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `synth-ai` package are documented here.
 
+## 0.11.3 — 2026-06-18
+
+### Changed
+
+- Package README and metadata now lead with Managed Research, Research Factory,
+  and GEPA/GELO optimizer workflows instead of lower-level infrastructure
+  nouns.
+- Public package docs now keep `synth-ai[research]` as the canonical install
+  path and describe the standalone `managed-research` package as legacy
+  compatibility only.
+- Managed Research SDK/MCP package docs now point at in-package files instead
+  of retired standalone checkout paths.
+
 ## 0.11.2 — 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.11.2-orange synth-ai==0.11.2 -->
+<!-- CI release pins: PyPI-0.11.3-orange synth-ai==0.11.3 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/README.md
+++ b/README.md
@@ -6,20 +6,22 @@
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![Python versions](https://img.shields.io/pypi/pyversions/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 
-Python SDK and CLI for Synth infrastructure surfaces: tunnels, pools, and hosted containers.
+Python SDK and CLI for Synth Managed Research, Research Factory, GEPA/GELO
+optimizer workflows, and the lower-level infrastructure surfaces those products
+use.
 
 **Documentation:** https://docs.usesynth.ai/sdk/overview
 
 ## Installation
 
 ```bash
-uv add synth-ai
+uv add "synth-ai[research]"
 ```
 
 Or install with pip:
 
 ```bash
-pip install synth-ai
+pip install "synth-ai[research]"
 ```
 
 ## Authenticate
@@ -57,19 +59,22 @@ The CLI also reads `SYNTH_BACKEND_URL` and accepts `--backend-url`.
 from synth_ai import SynthClient
 
 client = SynthClient()
+research = client.research
 
-print(client.containers.list())
-print(client.tunnels.health())
-print(client.pools.list())
+run = research.runs.start(
+    "Inspect this repository and leave a reviewable report.",
+    work_mode="directed_effort",
+    providers=[{"provider": "openrouter"}],
+    runbook="lite",
+)
+
+print(run.run_id)
 ```
 
 ## CLI
 
 ```bash
 synth-ai --help
-synth-ai containers list
-synth-ai tunnels health
-synth-ai pools list
 ```
 
 ## Public Surface
@@ -78,19 +83,26 @@ Use `SynthClient` as the front door:
 
 | Surface | Client namespace | Use it for |
 | --- | --- | --- |
-| **Managed Research / Factory** | `client.research` | Hosted research runs, projects, evidence, MCP (`synth-ai[research]`). |
-| Containers | `client.containers` | Hosted container records and lifecycle operations. |
-| Tunnels | `client.tunnels` | Managed tunnel records, leases, health, and rotation. |
-| Pools | `client.pools` | Container pools, tasks, rollouts, artifacts, usage, and events. |
-| CLI | `synth-ai` | Terminal access to containers, tunnels, and pools. |
+| Managed Research | `client.research` | Hosted research workers, repo runs, evidence, checkpoints, MCP, usage, and reports. |
+| Research Factory | `client.research` | Programmatic multi-run research campaigns on the same control plane. |
+| Hosted Optimizers | `synth-optimizers` + `synth-ai` auth | GEPA and GELO hosted optimizer workflows. |
+| Containers | `client.containers` | Lower-level hosted container records and lifecycle operations. |
+| Tunnels | `client.tunnels` | Lower-level managed tunnel records, leases, health, and rotation. |
+| Pools | `client.pools` | Lower-level container pools, tasks, rollouts, artifacts, usage, and events. |
 
-Use [Managed Research](https://docs.usesynth.ai/managed-research/intro) when you
-want hosted research workers, repo runs, evidence, checkpoints, MCP, or final
-reports.
+For agent clients, connect to the hosted Managed Research MCP server:
+
+```bash
+codex mcp add synth-managed-research --url https://api.usesynth.ai/mcp
+```
 
 ## Links
 
 - [Install and authenticate](https://docs.usesynth.ai/sdk/install-and-auth)
+- [Managed Research](https://docs.usesynth.ai/managed-research/intro)
+- [Managed Research MCP quickstart](https://docs.usesynth.ai/managed-research/mcp-quickstart)
+- [Research Factory](https://docs.usesynth.ai/managed-research/research-factory)
+- [Hosted Optimizers](https://docs.usesynth.ai/sdk/hosted-optimizers)
 - [SynthClient guide](https://docs.usesynth.ai/sdk/synth-client)
 - [Tunnels](https://docs.usesynth.ai/sdk/tunnels)
 - [Pools](https://docs.usesynth.ai/sdk/pools)
@@ -112,5 +124,3 @@ uv run ty check
 Optional: install [Lefthook](https://github.com/evilmartians/lefthook) and run
 `lefthook install` to run formatting, linting, and type checks on staged Python
 files.
-
-[SMR Handoff X thread](https://github.com/usesynth/smr-handoff/blob/main/marketing/smr-handoff-x-thread.md) — hand agent tasks to [Managed Research](https://usesynth.ai/smr) from Cursor, Codex, or Claude Code ([repo](https://github.com/usesynth/smr-handoff)).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![Python versions](https://img.shields.io/pypi/pyversions/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 
-Python SDK and CLI for Synth Managed Research, Research Factory, GEPA/GELO
-optimizer workflows, and the lower-level infrastructure surfaces those products
-use.
+Python SDK and CLI for Synth Managed Research, Research Factory, and GEPA/GELO
+optimizer workflows. Lower-level infrastructure namespaces remain available for
+advanced workflows that need them.
 
-**Documentation:** https://docs.usesynth.ai/sdk/overview
+**Documentation:** https://docs.usesynth.ai/managed-research/intro
 
 ## Installation
 
@@ -86,9 +86,7 @@ Use `SynthClient` as the front door:
 | Managed Research | `client.research` | Hosted research workers, repo runs, evidence, checkpoints, MCP, usage, and reports. |
 | Research Factory | `client.research` | Programmatic multi-run research campaigns on the same control plane. |
 | Hosted Optimizers | `synth-optimizers` + `synth-ai` auth | GEPA and GELO hosted optimizer workflows. |
-| Containers | `client.containers` | Lower-level hosted container records and lifecycle operations. |
-| Tunnels | `client.tunnels` | Lower-level managed tunnel records, leases, health, and rotation. |
-| Pools | `client.pools` | Lower-level container pools, tasks, rollouts, artifacts, usage, and events. |
+| Advanced infrastructure | `client.containers`, `client.tunnels`, `client.pools` | Lower-level records, leases, rollouts, artifacts, usage, and events used by advanced integrations. |
 
 For agent clients, connect to the hosted Managed Research MCP server:
 
@@ -104,9 +102,6 @@ codex mcp add synth-managed-research --url https://api.usesynth.ai/mcp
 - [Research Factory](https://docs.usesynth.ai/managed-research/research-factory)
 - [Hosted Optimizers](https://docs.usesynth.ai/sdk/hosted-optimizers)
 - [SynthClient guide](https://docs.usesynth.ai/sdk/synth-client)
-- [Tunnels](https://docs.usesynth.ai/sdk/tunnels)
-- [Pools](https://docs.usesynth.ai/sdk/pools)
-- [Containers](https://docs.usesynth.ai/sdk/containers)
 - [SDK reference](https://docs.usesynth.ai/reference/sdk)
 - [OpenAPI contracts](https://docs.usesynth.ai/reference/openapi)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "synth-ai"
 version = "0.11.2"
-description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
+description = "Synth SDK for Managed Research, Research Factory, and GEPA/GELO optimizer workflows"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.11.2"
+version = "0.11.3"
 description = "Synth SDK for Managed Research, Research Factory, and GEPA/GELO optimizer workflows"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/README.md
+++ b/synth_ai/README.md
@@ -1,17 +1,24 @@
 # `synth_ai` Package
 
-Runtime package for the public Synth AI SDK and CLI.
+Runtime package for the public Synth AI SDK, Managed Research client, Research
+Factory client surface, MCP server, and CLI.
 
-The public first-mile surface is intentionally small:
+The public first-mile surface is intentionally small and product-led:
 
 - `SynthClient`
 - `AsyncSynthClient`
+- `client.research`
+- `synth-ai-managed-research-mcp`
+- `synth-ai` CLI
+
+Advanced infrastructure namespaces are still available when a workflow needs
+direct access to hosted infrastructure records:
+
 - `client.containers`
 - `client.tunnels`
 - `client.pools`
-- `synth-ai` CLI
 
-Public docs live at https://docs.usesynth.ai/sdk/overview.
+Public docs live at https://docs.usesynth.ai/managed-research/intro.
 
 ## Package Structure
 
@@ -19,6 +26,7 @@ Public docs live at https://docs.usesynth.ai/sdk/overview.
 synth_ai/
 ├── client.py       # SynthClient and AsyncSynthClient composition layer
 ├── sdk/            # Public client modules and request/response contracts
+├── managed_research/ # Managed Research SDK, models, schemas, and MCP server
 ├── core/           # Shared runtime helpers and errors
 ├── cli/            # CLI commands for containers, tunnels, and pools
 └── __init__.py     # Package version and top-level exports
@@ -43,12 +51,16 @@ Prefer the front-door client:
 from synth_ai import SynthClient
 
 client = SynthClient()
-client.containers.list()
-client.tunnels.health()
-client.pools.list()
+research = client.research
+run = research.runs.start(
+    "Inspect this repository and leave a reviewable report.",
+    work_mode="directed_effort",
+    providers=[{"provider": "openrouter"}],
+    runbook="lite",
+)
 ```
 
-Use specific clients only when you need lower-level control:
+Use lower-level clients only when you need direct infrastructure control:
 
 ```python
 from synth_ai.sdk.containers import ContainersClient

--- a/synth_ai/managed_research/__init__.py
+++ b/synth_ai/managed_research/__init__.py
@@ -276,6 +276,8 @@ from synth_ai.managed_research.sdk import (
     ExportsAPI,
     FactoriesAPI,
     FilesAPI,
+    GithubAPI,
+    IntegrationsAPI,
     LogsAPI,
     ManagedResearchClient,
     ManagedResearchProjectClient,

--- a/synth_ai/managed_research/__init__.py
+++ b/synth_ai/managed_research/__init__.py
@@ -360,6 +360,8 @@ __all__ = [
     "CredentialsAPI",
     "DatasetsAPI",
     "DEFAULT_TIMEOUT_SECONDS",
+    "GithubAPI",
+    "IntegrationsAPI",
     "ExportsAPI",
     "OPENAI_TRANSPORT_MODE_AUTO",
     "OPENAI_TRANSPORT_MODE_BACKEND_BFF",

--- a/synth_ai/managed_research/mcp/README.md
+++ b/synth_ai/managed_research/mcp/README.md
@@ -1,12 +1,12 @@
 # MCP
 
-This package owns the canonical MCP surface for `managed-research`.
+This package owns the canonical Managed Research MCP surface inside
+`synth-ai`.
 
-Surface note: MCP tools call the authenticated private-beta Managed Research
-API. When tool or schema descriptions say public, they mean the stable API
-contract. Managed Research beta access is an account/org entitlement enforced by
-the backend through entitlement checks and launch preflight, not by narrowing
-the MCP tool list.
+Surface note: MCP tools call the authenticated Managed Research API. When tool
+or schema descriptions say public, they mean the stable API contract. Managed
+Research access is an account/org entitlement enforced by the backend through
+entitlement checks and launch preflight, not by narrowing the MCP tool list.
 
 What belongs here:
 - tool registration, schemas, and scope metadata

--- a/synth_ai/managed_research/mcp/server.py
+++ b/synth_ai/managed_research/mcp/server.py
@@ -1389,6 +1389,12 @@ class ManagedResearchMcpServer:
             result = client.get_project_usage(project_id)
             return asdict(result) if is_dataclass(result) else result
 
+    def _tool_get_project_economics(self, args: JSONDict) -> Any:
+        project_id = require_string(args, "project_id")
+        with self._client_from_args(args) as client:
+            result = client.get_project_economics(project_id)
+            return asdict(result) if is_dataclass(result) else result
+
     def _tool_get_project_git(self, args: JSONDict) -> Any:
         project_id = require_string(args, "project_id")
         with self._client_from_args(args) as client:

--- a/synth_ai/managed_research/mcp/server.py
+++ b/synth_ai/managed_research/mcp/server.py
@@ -42,6 +42,7 @@ from synth_ai.managed_research.mcp.tools.datasets import build_dataset_tools
 from synth_ai.managed_research.mcp.tools.exports import build_export_tools
 from synth_ai.managed_research.mcp.tools.factories import build_factory_tools
 from synth_ai.managed_research.mcp.tools.files import build_file_tools
+from synth_ai.managed_research.mcp.tools.github import build_github_tools
 from synth_ai.managed_research.mcp.tools.integrations import build_integration_tools
 from synth_ai.managed_research.mcp.tools.logs import build_log_tools
 from synth_ai.managed_research.mcp.tools.models import build_model_tools
@@ -221,6 +222,7 @@ class ManagedResearchMcpServer:
             *build_project_tools(self),
             *build_factory_tools(self),
             *build_workspace_input_tools(self),
+            *build_github_tools(self),
             *build_export_tools(self),
             *build_repo_tools(self),
             *build_dataset_tools(self),
@@ -489,6 +491,27 @@ class ManagedResearchMcpServer:
             if project_id:
                 checks["project_status"] = client.get_project_status(project_id)
         return {"ok": True, "checks": checks}
+
+    def _tool_setup_github_status(self, args: JSONDict) -> Any:
+        with self._client_from_args(args) as client:
+            return client.get_github_status()
+
+    def _tool_setup_github_start_oauth(self, args: JSONDict) -> Any:
+        redirect_uri = optional_string(args, "redirect_uri")
+        with self._client_from_args(args) as client:
+            return client.start_github_oauth(redirect_uri=redirect_uri)
+
+    def _tool_setup_github_list_repos(self, args: JSONDict) -> Any:
+        page = optional_int(args, "page")
+        per_page = optional_int(args, "per_page")
+        with self._client_from_args(args) as client:
+            return {
+                "repos": client.list_github_repos(page=page, per_page=per_page),
+            }
+
+    def _tool_setup_github_disconnect(self, args: JSONDict) -> Any:
+        with self._client_from_args(args) as client:
+            return client.disconnect_github()
 
     def _tool_setup_exports_list_targets(self, args: JSONDict) -> Any:
         with self._client_from_args(args) as client:

--- a/synth_ai/managed_research/mcp/tools/__init__.py
+++ b/synth_ai/managed_research/mcp/tools/__init__.py
@@ -4,6 +4,7 @@ from synth_ai.managed_research.mcp.tools.datasets import build_dataset_tools
 from synth_ai.managed_research.mcp.tools.exports import build_export_tools
 from synth_ai.managed_research.mcp.tools.factories import build_factory_tools
 from synth_ai.managed_research.mcp.tools.files import build_file_tools
+from synth_ai.managed_research.mcp.tools.github import build_github_tools
 from synth_ai.managed_research.mcp.tools.models import build_model_tools
 from synth_ai.managed_research.mcp.tools.outputs import build_output_tools
 from synth_ai.managed_research.mcp.tools.progress import build_progress_tools
@@ -19,6 +20,7 @@ __all__ = [
     "build_export_tools",
     "build_factory_tools",
     "build_file_tools",
+    "build_github_tools",
     "build_model_tools",
     "build_output_tools",
     "build_progress_tools",

--- a/synth_ai/managed_research/mcp/tools/github.py
+++ b/synth_ai/managed_research/mcp/tools/github.py
@@ -1,0 +1,50 @@
+"""Setup-stage GitHub tool definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from synth_ai.managed_research.mcp.registry import ToolDefinition, tool_schema
+
+
+def build_github_tools(server: Any) -> list[ToolDefinition]:
+    return [
+        ToolDefinition(
+            name="smr_setup_github_status",
+            description="Fetch org-level GitHub connection status.",
+            input_schema=tool_schema({}, required=[]),
+            handler=server._tool_setup_github_status,
+        ),
+        ToolDefinition(
+            name="smr_setup_github_start_oauth",
+            description="Start the org-level GitHub connect flow.",
+            input_schema=tool_schema(
+                {
+                    "redirect_uri": {"type": "string"},
+                },
+                required=[],
+            ),
+            handler=server._tool_setup_github_start_oauth,
+        ),
+        ToolDefinition(
+            name="smr_setup_github_list_repos",
+            description="List repos available through the org-level GitHub integration.",
+            input_schema=tool_schema(
+                {
+                    "page": {"type": "integer"},
+                    "per_page": {"type": "integer"},
+                },
+                required=[],
+            ),
+            handler=server._tool_setup_github_list_repos,
+        ),
+        ToolDefinition(
+            name="smr_setup_github_disconnect",
+            description="Disconnect the org-level GitHub integration.",
+            input_schema=tool_schema({}, required=[]),
+            handler=server._tool_setup_github_disconnect,
+        ),
+    ]
+
+
+__all__ = ["build_github_tools"]

--- a/synth_ai/managed_research/mcp/tools/usage.py
+++ b/synth_ai/managed_research/mcp/tools/usage.py
@@ -130,6 +130,20 @@ def build_usage_tools(server: Any) -> list[ToolDefinition]:
             ),
             handler=server._tool_get_project_usage,
         ),
+        ToolDefinition(
+            name="smr_get_project_economics",
+            description="Fetch canonical project economics: usage, entitlements, and overlay posture.",
+            input_schema=tool_schema(
+                {
+                    "project_id": {
+                        "type": "string",
+                        "description": "Project id.",
+                    },
+                },
+                required=["project_id"],
+            ),
+            handler=server._tool_get_project_economics,
+        ),
     ]
 
 

--- a/synth_ai/managed_research/models/README.md
+++ b/synth_ai/managed_research/models/README.md
@@ -17,14 +17,14 @@ Current guidance:
 - serialize to plain dicts only at the final transport edge
 - prefer explicit dataclasses/enums over open-ended `dict[str, Any]` for primary concepts
 
-New run-control models live in [`run_timeline.py`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/models/run_timeline.py):
+New run-control models live in [`run_timeline.py`](run_timeline.py):
 - `SmrLogicalTimeline`
 - `SmrLogicalTimelineNode`
 - `SmrBranchMode`
 - `SmrRunBranchRequest`
 - `SmrRunBranchResponse`
 
-High-signal typed response models currently live in [`types.py`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/models/types.py):
+High-signal typed response models currently live in [`types.py`](types.py):
 - `ProjectSetupAuthority`
 - `LaunchPreflight`
 - `RunProgress`
@@ -32,4 +32,5 @@ High-signal typed response models currently live in [`types.py`](/Users/joshpurt
 - `WorkspaceInputsState`
 - `WorkspaceUploadResult`
 
-Generated compatibility exports remain under [`generated/v1`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/models/generated/v1/__init__.py).
+Generated compatibility exports remain under
+[`generated/v1`](generated/v1/__init__.py).

--- a/synth_ai/managed_research/sdk/README.md
+++ b/synth_ai/managed_research/sdk/README.md
@@ -1,11 +1,11 @@
 # SDK
 
-This subtree owns the Python control-plane client and the typed namespace wrappers built on top of it.
+This subtree owns the Python Managed Research control-plane client and the typed
+namespace wrappers built on top of it.
 
-Surface note: this SDK targets the authenticated private-beta Managed Research
-API. Managed Research beta access is an account/org entitlement enforced by the
-backend through entitlement checks and launch preflight rather than by a
-separate SDK client fork.
+Surface note: this SDK targets the authenticated Managed Research API. Access is
+an account/org entitlement enforced by the backend through entitlement checks
+and launch preflight rather than by a separate SDK client fork.
 
 Ownership:
 - `client.py` owns transport-facing request building and raw backend interaction
@@ -18,7 +18,7 @@ Guidelines:
 - when a backend route has a stable response concept, return a typed model from the namespace API when practical
 
 Current typed namespace returns:
-- [`project.py`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/sdk/project.py)
+- [`project.py`](project.py)
   - bound project setup via `client.project(id).setup.get()` and
     `client.project(id).setup.prepare()`
   - bound project launch preflight via `client.project(id).runs.preflight(...)`
@@ -29,14 +29,14 @@ Current typed namespace returns:
   - review-gated project ChangeSets via `client.project(id).changesets.*`
   - project-run actor controls via `client.project(id).runs.pause_actor(...)`,
     `resume_actor(...)`, and `interrupt_actor(...)`
-- [`progress.py`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/sdk/progress.py)
+- [`progress.py`](progress.py)
   - `ProjectSetupAuthority` via `get_project_setup_authority(...)`
   - `LaunchPreflight` via `get_launch_preflight(...)`
-- [`runs.py`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/sdk/runs.py)
+- [`runs.py`](runs.py)
   - `ManagedResearchRun` via `get(run_id, project_id=...)`
   - `SmrLogicalTimeline` via `get_logical_timeline(project_id, run_id)`
   - `SmrRunBranchResponse` via `branch_from_checkpoint(...)`
-- [`workspace_inputs.py`](/Users/joshpurtell/Documents/GitHub/managed-research/managed_research/sdk/workspace_inputs.py)
+- [`workspace_inputs.py`](workspace_inputs.py)
   - `WorkspaceInputsState`
   - `WorkspaceUploadResult`
 
@@ -56,9 +56,9 @@ Noun-first namespaces now mirror the customer surface:
 Contract posture:
 
 - backend route and schema shape stay authoritative through
-  `/Users/joshpurtell/Documents/GitHub/backend/smr_openapi.yaml`
-- backend-to-SDK drift is checked with
-  `/Users/joshpurtell/Documents/GitHub/backend/scripts/validate_smr_openapi.py`
+  `backend/smr_openapi.yaml`
+- backend-to-SDK drift is checked with the backend
+  `scripts/validate_smr_openapi.py` contract validator
 - older names may remain as wrappers, but new noun behavior belongs only on the
   flat namespaces above
 

--- a/synth_ai/managed_research/sdk/__init__.py
+++ b/synth_ai/managed_research/sdk/__init__.py
@@ -361,6 +361,8 @@ __all__ = [
     "PublicationPolicy",
     "RecurrencePolicy",
     "FilesAPI",
+    "GithubAPI",
+    "IntegrationsAPI",
     "GitHubInstallation",
     "OPENAI_TRANSPORT_MODE_AUTO",
     "OPENAI_TRANSPORT_MODE_BACKEND_BFF",

--- a/synth_ai/managed_research/sdk/__init__.py
+++ b/synth_ai/managed_research/sdk/__init__.py
@@ -289,6 +289,8 @@ from synth_ai.managed_research.sdk.environments import EnvironmentsAPI
 from synth_ai.managed_research.sdk.exports import ExportsAPI
 from synth_ai.managed_research.sdk.factories import EffortsAPI, FactoriesAPI
 from synth_ai.managed_research.sdk.files import FilesAPI
+from synth_ai.managed_research.sdk.github import GithubAPI
+from synth_ai.managed_research.sdk.integrations import IntegrationsAPI
 from synth_ai.managed_research.sdk.logs import LogsAPI
 from synth_ai.managed_research.sdk.models import ModelsAPI
 from synth_ai.managed_research.sdk.outputs import OutputsAPI

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -159,6 +159,8 @@ from synth_ai.managed_research.sdk.environments import EnvironmentsAPI
 from synth_ai.managed_research.sdk.exports import ExportsAPI
 from synth_ai.managed_research.sdk.factories import EffortsAPI, FactoriesAPI
 from synth_ai.managed_research.sdk.files import FilesAPI
+from synth_ai.managed_research.sdk.github import GithubAPI
+from synth_ai.managed_research.sdk.integrations import IntegrationsAPI
 from synth_ai.managed_research.sdk.logs import LogsAPI
 from synth_ai.managed_research.sdk.models import ModelsAPI
 from synth_ai.managed_research.sdk.outputs import OutputsAPI
@@ -901,6 +903,8 @@ class ManagedResearchClient:
     _secrets_api: SecretsAPI | None = field(init=False, default=None, repr=False)
     _environments_api: EnvironmentsAPI | None = field(init=False, default=None, repr=False)
     _logs_api: LogsAPI | None = field(init=False, default=None, repr=False)
+    _github_api: GithubAPI | None = field(init=False, default=None, repr=False)
+    _integrations_api: IntegrationsAPI | None = field(init=False, default=None, repr=False)
     _usage_api: UsageAPI | None = field(init=False, default=None, repr=False)
     _trained_models_api: TrainedModelsAPI | None = field(init=False, default=None, repr=False)
     _run_cost_api: RunCostAPI | None = field(init=False, default=None, repr=False)
@@ -1061,6 +1065,59 @@ class ManagedResearchClient:
         if self._logs_api is None:
             self._logs_api = LogsAPI(self)
         return self._logs_api
+
+    @property
+    def github(self) -> GithubAPI:
+        if self._github_api is None:
+            self._github_api = GithubAPI(self)
+        return self._github_api
+
+    @property
+    def integrations(self) -> IntegrationsAPI:
+        if self._integrations_api is None:
+            self._integrations_api = IntegrationsAPI(self)
+        return self._integrations_api
+
+    def get_github_status(self) -> dict[str, Any]:
+        return _coerce_dict(
+            self._request_json("GET", "/smr/github/status"),
+            label="get_github_status",
+        )
+
+    def start_github_oauth(
+        self,
+        *,
+        redirect_uri: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if redirect_uri is not None:
+            payload["redirect_uri"] = redirect_uri
+        return _coerce_dict(
+            self._request_json("POST", "/smr/github/oauth/start", json_body=payload),
+            label="start_github_oauth",
+        )
+
+    def list_github_repos(
+        self,
+        *,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> list[dict[str, Any]]:
+        payload = _coerce_dict(
+            self._request_json(
+                "GET",
+                "/smr/github/repos",
+                params=build_query_params(page=page, per_page=per_page),
+            ),
+            label="list_github_repos",
+        )
+        return _coerce_dict_list(payload.get("repos") or [], label="list_github_repos.repos")
+
+    def disconnect_github(self) -> dict[str, Any]:
+        return _coerce_dict(
+            self._request_json("POST", "/smr/github/disconnect"),
+            label="disconnect_github",
+        )
 
     def project(self, project_id: str) -> ManagedResearchProjectClient:
         return ManagedResearchProjectClient(

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -30,6 +30,7 @@ from synth_ai.managed_research.models import (
     FactoryProjectLinkRequest,
     FactoryProjectPatchRequest,
     FactoryWakeDueRequest,
+    SmrProjectEconomics,
     SmrProjectUsage,
     SmrResourceLimitExtension,
     SmrResourceLimitProgress,
@@ -1243,6 +1244,9 @@ class ManagedResearchClient:
 
     def get_project_usage(self, project_id: str) -> SmrProjectUsage:
         return self.usage.get_project_usage(project_id)
+
+    def get_project_economics(self, project_id: str) -> SmrProjectEconomics:
+        return self.usage.get_project_economics(project_id)
 
     def _request_json(
         self,

--- a/synth_ai/managed_research/sdk/github.py
+++ b/synth_ai/managed_research/sdk/github.py
@@ -1,0 +1,33 @@
+"""Org-scoped GitHub namespace for the flatter noun-first SDK surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from synth_ai.managed_research.sdk._base import _ClientNamespace
+
+
+class GithubAPI(_ClientNamespace):
+    def status(self) -> dict[str, Any]:
+        return self._client.get_github_status()
+
+    def start_oauth(
+        self,
+        *,
+        redirect_uri: str | None = None,
+    ) -> dict[str, Any]:
+        return self._client.start_github_oauth(redirect_uri=redirect_uri)
+
+    def list_repos(
+        self,
+        *,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return self._client.list_github_repos(page=page, per_page=per_page)
+
+    def disconnect(self) -> dict[str, Any]:
+        return self._client.disconnect_github()
+
+
+__all__ = ["GithubAPI"]

--- a/synth_ai/managed_research/sdk/integrations.py
+++ b/synth_ai/managed_research/sdk/integrations.py
@@ -1,0 +1,54 @@
+"""Integration-oriented SDK namespace."""
+
+from __future__ import annotations
+
+from synth_ai.managed_research.models.local_execution_profile import LocalPublicationReadiness
+from synth_ai.managed_research.sdk._base import _ClientNamespace
+
+
+class IntegrationsAPI(_ClientNamespace):
+    """Integration helpers for first-party local and hosted flows."""
+
+    def register_local_github_credential(
+        self,
+        project_id: str,
+        *,
+        repo: str,
+        access_token: str,
+        pr_write_enabled: bool = True,
+    ) -> dict[str, object]:
+        return self._client.register_local_github_credential(
+            project_id,
+            repo=repo,
+            access_token=access_token,
+            pr_write_enabled=pr_write_enabled,
+        )
+
+    def register_local_github_repo_credential(
+        self,
+        *,
+        repo: str,
+        access_token: str,
+        pr_write_enabled: bool = True,
+    ) -> dict[str, object]:
+        return self._client.register_local_github_repo_credential(
+            repo=repo,
+            access_token=access_token,
+            pr_write_enabled=pr_write_enabled,
+        )
+
+    def get_local_publication_readiness(
+        self,
+        project_id: str,
+        *,
+        repo: str | None = None,
+        pr_write_enabled: bool = True,
+    ) -> LocalPublicationReadiness:
+        return self._client.get_local_publication_readiness(
+            project_id,
+            repo=repo,
+            pr_write_enabled=pr_write_enabled,
+        )
+
+
+__all__ = ["IntegrationsAPI"]

--- a/synth_ai/managed_research/sdk/usage.py
+++ b/synth_ai/managed_research/sdk/usage.py
@@ -8,6 +8,7 @@ from synth_ai.managed_research.errors import SmrApiError
 from synth_ai.managed_research.models import (
     BillingEntitlementSnapshot,
     OrgLimits,
+    SmrProjectEconomics,
     SmrProjectUsage,
     SmrResourceLimitExtension,
     SmrResourceLimitProgress,
@@ -231,6 +232,13 @@ class UsageAPI(_ClientNamespace):
         return SmrProjectUsage.from_wire(
             _raise_on_error_payload(
                 self._client._request_json("GET", f"/smr/projects/{project_id}/usage")
+            )
+        )
+
+    def get_project_economics(self, project_id: str) -> SmrProjectEconomics:
+        return SmrProjectEconomics.from_wire(
+            _raise_on_error_payload(
+                self._client._request_json("GET", f"/smr/projects/{project_id}/economics")
             )
         )
 

--- a/synth_ai/sdk/README.md
+++ b/synth_ai/sdk/README.md
@@ -1,6 +1,8 @@
-# SDK Modules
+# Lower-Level SDK Modules
 
-Public HTTP clients and contracts for the Synth AI infrastructure SDK.
+HTTP clients and contracts for lower-level Synth infrastructure surfaces used by
+the product SDK. User-facing examples should start with Managed Research and
+Research Factory through `SynthClient().research`.
 
 Prefer the top-level client in user-facing examples:
 
@@ -8,12 +10,11 @@ Prefer the top-level client in user-facing examples:
 from synth_ai import SynthClient
 
 client = SynthClient()
-client.containers.list()
-client.tunnels.health()
-client.pools.list()
+research = client.research
 ```
 
-Use module-level clients when implementing or testing a specific surface:
+Use module-level infrastructure clients when implementing or testing a specific
+advanced surface:
 
 ```python
 from synth_ai.sdk.containers import ContainersClient
@@ -22,7 +23,7 @@ from synth_ai.sdk.pools import ContainerPoolsClient
 from synth_ai.sdk.tunnels import TunnelsClient
 ```
 
-## Supported Public Surfaces
+## Supported Advanced Surfaces
 
 - hosted containers
 - managed tunnels and tunnel leases
@@ -36,11 +37,12 @@ from synth_ai.sdk.tunnels import TunnelsClient
 - `/v1/pools/*`
 - `/v1/rollouts/*`
 - `/api/managed-agents/anthropic/v1/*`
-- `/anthropic/v1/*` for direct local Horizons Private usage
 
 ## Ownership Rules
 
 - Keep transport details in SDK modules.
 - Keep shared error and environment helpers in `core/`.
 - Keep front-door composition in `client.py`.
-- Keep public examples focused on `SynthClient`, tunnels, pools, and containers.
+- Keep public examples focused on `SynthClient`, Managed Research, Research
+  Factory, and documented optimizer workflows. Infrastructure examples belong
+  only where those lower-level surfaces are deliberately documented.


### PR DESCRIPTION
Aligns the public `synth-ai` package copy with the current product map and makes the cleanup release-version-ready.

Scope:
- Makes the PyPI metadata description Managed Research / Research Factory / GEPA / GELO first.
- Makes `synth-ai[research]` the install path shown in README.
- Replaces infra-first quickstart snippets with `SynthClient().research`.
- Adds hosted Managed Research MCP setup.
- Restores public Managed Research SDK/MCP exports needed by CI:
  - `GithubAPI`, `IntegrationsAPI`
  - `client.github`, `client.integrations`
  - GitHub setup MCP tools
  - project economics wrapper
- Bumps target package version to `0.11.3`, above live PyPI `0.11.2`.
- Finishes package-doc positioning so public README/package READMEs lead with Managed Research / Research Factory, lower-level infrastructure is framed as advanced support, and Managed Research docs link to in-package files instead of the retired standalone checkout.

Verification:
- GitHub CI green on `798cee86`: Check README Version, Lint, Tests, Type Check.
- Targeted grep found no old infra-first description, stale plain `synth-ai` install snippets, SMR handoff link, old `/smr` URL, retired standalone checkout paths, `private-beta`, or MIPRO/Graph/Horizons mentions in touched package surfaces. Remaining `0.11.2` hits are historical changelog entries.
- `git diff --check` is clean.

Release gate:
- Tracked in `specifications/daily/2026-06-17/launch_checklist_2026-06-17.md`, Section 21.
- Do not treat this as live registry cleanup until PR merge, PyPI publish/metadata refresh, fresh install/MCP smoke, and live PyPI proof are recorded.
