### PR TITLE
Avoid duplicate PyPI publish on release event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,46 @@ permissions:
   id-token: write
 
 jobs:
+  check-version:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      needs_publish: ${{ steps.check.outputs.needs_publish }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Extract release version
+        id: version
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION"
+
+      - name: Check PyPI version
+        id: pypi
+        run: |
+          PYPI_VERSION="$(curl -fsSL https://pypi.org/pypi/synth-ai/json | python -c 'import json, sys; print((json.load(sys.stdin).get("info") or {}).get("version") or "")')"
+          if [ -z "$PYPI_VERSION" ]; then
+            PYPI_VERSION="0.0.0"
+          fi
+          echo "version=$PYPI_VERSION" >> "$GITHUB_OUTPUT"
+          echo "PyPI version: $PYPI_VERSION"
+
+      - name: Decide whether PyPI publish is needed
+        id: check
+        run: |
+          RELEASE="${{ steps.version.outputs.version }}"
+          PYPI="${{ steps.pypi.outputs.version }}"
+          if [ "$RELEASE" = "$PYPI" ]; then
+            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Release $RELEASE is already on PyPI; skipping upload."
+          else
+            echo "needs_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Release $RELEASE is not on PyPI latest ($PYPI); uploading."
+          fi
+
   build-distributions:
+    needs: [check-version]
+    if: needs.check-version.outputs.needs_publish == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +74,8 @@ jobs:
 
   pypi-publish:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [build-distributions]
+    needs: [check-version, build-distributions]
+    if: needs.check-version.outputs.needs_publish == 'true'
     environment:
       name: pypi
       url: https://pypi.org/project/synth-ai/


### PR DESCRIPTION
This is a launch release-path hardening fix for synth-ai 0.11.3.\n\nProblem: main-push auto-publish publishes to PyPI and then creates a GitHub Release; the release-created workflow can then try to publish the same version again.\n\nFix: make the release-created PyPI workflow check the release tag version against PyPI latest first. If the release version is already on PyPI, it skips build/upload. Manual release-created publishes still work when PyPI latest differs.\n\nValidation: git diff --check. Local YAML parsing was not run because PyYAML/actionlint are unavailable locally; GitHub Actions should validate workflow syntax.\n\nNo prod release/publish is performed by this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/synth-laboratories/synth-ai/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->