### PR TITLE
chore(release): synth-ai 0.11.5 billing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `synth-ai` package are documented here.
 
+## 0.11.5 — 2026-06-24
+
+### Added
+
+- **`client.billing`** namespace — typed SMR Codex-style billing SDK:
+  - `get_catalog()`, `get_plan()`, `get_run_drawdown(run_id)`, `preflight_run(...)`,
+    factory-effort drawdown/preflight, and admin grant helpers matching
+    `GET /smr/billing/plan`, `/smr/billing/catalog`, run drawdown, and preflight routes.
+
+### Notes
+
+- Ships the billing SDK already merged on `dev`; no Factory surface changes.
+- Pair with backend billing routes on the same deploy train.
+
 ## 0.11.4 — 2026-06-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.11.4"
+version = "0.11.5"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"


### PR DESCRIPTION
PyPI 0.11.5 published. Adds client.billing namespace changelog.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/synth-laboratories/synth-ai/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->