### PR TITLE
chore(smr): refresh managed research contract schemas

### DIFF
--- a/synth_ai/cli/dev_envs.py
+++ b/synth_ai/cli/dev_envs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import asdict, is_dataclass
-from typing import Any
+from typing import Any, Mapping
 
 import click
 
@@ -136,13 +136,12 @@ def _git_proofs_from_evidence(
         run_id = str(item.get("run_id") or "").strip()
         if expected_run_ids and run_id not in expected_run_ids:
             continue
-        git = dict(item.get("git")) if isinstance(item.get("git"), dict) else {}
-        run_git = (
-            dict(git.get("run_git_context")) if isinstance(git.get("run_git_context"), dict) else {}
-        )
-        project_git = (
-            dict(git.get("project_git")) if isinstance(git.get("project_git"), dict) else {}
-        )
+        git_raw = item.get("git")
+        git = dict(git_raw) if isinstance(git_raw, Mapping) else {}
+        run_git_raw = git.get("run_git_context")
+        run_git = dict(run_git_raw) if isinstance(run_git_raw, Mapping) else {}
+        project_git_raw = git.get("project_git")
+        project_git = dict(project_git_raw) if isinstance(project_git_raw, Mapping) else {}
         branch = str(run_git.get("branch") or project_git.get("default_branch") or "").strip()
         commit_sha = str(
             run_git.get("head_commit_sha") or project_git.get("commit_sha") or ""

--- a/synth_ai/managed_research/schemas/public_models.json
+++ b/synth_ai/managed_research/schemas/public_models.json
@@ -11,20 +11,12 @@
       "compute_pool_kind": "auth_pool",
       "compute_pool_id": "openai_chatgpt_pool",
       "route_kind": "codex_pool",
-      "provider_domicile": "us",
-      "route_regions": [
-        "us"
-      ],
-      "zdr_supported": true,
       "harnesses": [
         "codex"
       ],
       "aliases": [],
       "supported_reasoning_efforts": [
-        "low",
-        "medium",
-        "high",
-        "xhigh"
+        "medium"
       ],
       "default_reasoning_effort": "medium",
       "context_window_tokens": null,
@@ -52,18 +44,13 @@
       "compute_pool_kind": "auth_pool",
       "compute_pool_id": "openai_chatgpt_pool",
       "route_kind": "codex_pool",
-      "provider_domicile": null,
-      "route_regions": [],
-      "zdr_supported": null,
       "harnesses": [
         "codex"
       ],
       "aliases": [],
       "supported_reasoning_efforts": [
         "low",
-        "medium",
-        "high",
-        "xhigh"
+        "medium"
       ],
       "default_reasoning_effort": "medium",
       "context_window_tokens": null,
@@ -82,6 +69,40 @@
       }
     },
     {
+      "id": "gpt-5.4",
+      "display_name": "GPT-5.4",
+      "display_group": "standard_codex",
+      "public": true,
+      "provider": "openai",
+      "provider_model_id": "gpt-5.4",
+      "compute_pool_kind": "auth_pool",
+      "compute_pool_id": "openai_chatgpt_pool",
+      "route_kind": "codex_pool",
+      "harnesses": [
+        "codex"
+      ],
+      "aliases": [],
+      "supported_reasoning_efforts": [
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "context_window_tokens": null,
+      "max_output_tokens": 128000,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "0.0000025",
+        "cached_input_usd": "0.00000125",
+        "output_usd": "0.00001",
+        "reasoning_output_usd": "0.00001",
+        "source": "synth_contract",
+        "observed_at": "2026-04-21"
+      }
+    },
+    {
       "id": "gpt-5.5",
       "display_name": "GPT-5.5",
       "display_group": "standard_codex",
@@ -91,15 +112,11 @@
       "compute_pool_kind": "auth_pool",
       "compute_pool_id": "openai_chatgpt_pool",
       "route_kind": "codex_pool",
-      "provider_domicile": null,
-      "route_regions": [],
-      "zdr_supported": null,
       "harnesses": [
         "codex"
       ],
       "aliases": [],
       "supported_reasoning_efforts": [
-        "low",
         "medium",
         "high",
         "xhigh"
@@ -130,11 +147,6 @@
       "compute_pool_kind": "auth_pool",
       "compute_pool_id": "openai_chatgpt_pool",
       "route_kind": "codex_pool",
-      "provider_domicile": "us",
-      "route_regions": [
-        "us"
-      ],
-      "zdr_supported": true,
       "harnesses": [
         "codex"
       ],
@@ -142,8 +154,7 @@
       "supported_reasoning_efforts": [
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
       "default_reasoning_effort": "medium",
       "context_window_tokens": null,
@@ -162,23 +173,190 @@
       }
     },
     {
+      "id": "gpt-5.4-nano",
+      "display_name": "GPT-5.4 Nano",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "openai",
+      "provider_model_id": "gpt-5.4-nano",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "openai_api_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "codex"
+      ],
+      "aliases": [],
+      "supported_reasoning_efforts": [
+        "low"
+      ],
+      "default_reasoning_effort": "low",
+      "context_window_tokens": null,
+      "max_output_tokens": 128000,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "1E-7",
+        "cached_input_usd": "5E-8",
+        "output_usd": "4E-7",
+        "reasoning_output_usd": "4E-7",
+        "source": "synth_contract",
+        "observed_at": "2026-04-21"
+      }
+    },
+    {
+      "id": "gpt-oss-120b",
+      "display_name": "GPT-OSS 120B",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "groq",
+      "provider_model_id": "openai/gpt-oss-120b",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "groq_api_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "codex"
+      ],
+      "aliases": [
+        "openai/gpt-oss-120b"
+      ],
+      "supported_reasoning_efforts": [
+        "high"
+      ],
+      "default_reasoning_effort": "high",
+      "context_window_tokens": null,
+      "max_output_tokens": 131072,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "1.5E-7",
+        "cached_input_usd": "1.5E-7",
+        "output_usd": "7.5E-7",
+        "reasoning_output_usd": "7.5E-7",
+        "source": "synth_contract",
+        "observed_at": "2026-04-21"
+      }
+    },
+    {
+      "id": "anthropic/claude-sonnet-4-6",
+      "display_name": "Claude Sonnet 4.6",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "anthropic",
+      "provider_model_id": "claude-sonnet-4-6",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "anthropic_api_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "claude-sonnet-4-6"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": null,
+      "max_output_tokens": 64000,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "0.000003",
+        "cached_input_usd": "3E-7",
+        "output_usd": "0.000015",
+        "reasoning_output_usd": "0.000015",
+        "source": "anthropic_public_pricing",
+        "observed_at": "2026-04-21"
+      }
+    },
+    {
+      "id": "anthropic/claude-haiku-4-5-20251001",
+      "display_name": "Claude Haiku 4.5",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "anthropic",
+      "provider_model_id": "claude-haiku-4-5-20251001",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "anthropic_api_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "anthropic/claude-haiku-4-5",
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": null,
+      "max_output_tokens": 64000,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "0.000001",
+        "cached_input_usd": "1E-7",
+        "output_usd": "0.000005",
+        "reasoning_output_usd": "0.000005",
+        "source": "anthropic_public_pricing",
+        "observed_at": "2026-04-21"
+      }
+    },
+    {
+      "id": "x-ai/grok-4.1-fast",
+      "display_name": "Grok 4.1 Fast",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "openrouter",
+      "provider_model_id": "x-ai/grok-4.1-fast",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "openrouter_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "xai/grok-4-1-fast",
+        "x-ai/grok-4-1-fast",
+        "grok-4-1-fast",
+        "grok-4-1-fast-reasoning",
+        "grok-4-1-fast-non-reasoning"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": null,
+      "max_output_tokens": 32768,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "2E-7",
+        "cached_input_usd": "5E-8",
+        "output_usd": "5E-7",
+        "reasoning_output_usd": "5E-7",
+        "source": "openrouter_catalog",
+        "observed_at": "2026-04-21"
+      }
+    },
+    {
       "id": "x-ai/grok-4.3",
       "display_name": "Grok 4.3",
       "display_group": "additional_first_launch",
       "public": true,
-      "provider": "xai",
-      "provider_model_id": "grok-4.3",
+      "provider": "openrouter",
+      "provider_model_id": "x-ai/grok-4.3",
       "compute_pool_kind": "api_proxy_pool",
-      "compute_pool_id": "xai",
+      "compute_pool_id": "openrouter_pool",
       "route_kind": "api_proxy_pool",
-      "provider_domicile": "us",
-      "route_regions": [
-        "us"
-      ],
-      "zdr_supported": true,
       "harnesses": [
-        "opencode_sdk",
-        "codex"
+        "opencode_sdk"
       ],
       "aliases": [
         "xai/grok-4-3",
@@ -199,8 +377,8 @@
         "cached_input_usd": "2E-7",
         "output_usd": "0.0000025",
         "reasoning_output_usd": "0.0000025",
-        "source": "xai_model_api_pricing",
-        "observed_at": "2026-06-25"
+        "source": "openrouter_catalog",
+        "observed_at": "2026-05-04"
       }
     },
     {
@@ -213,11 +391,6 @@
       "compute_pool_kind": "api_proxy_pool",
       "compute_pool_id": "xai",
       "route_kind": "api_proxy_pool",
-      "provider_domicile": "us",
-      "route_regions": [
-        "us"
-      ],
-      "zdr_supported": true,
       "harnesses": [
         "codex"
       ],
@@ -246,6 +419,47 @@
       }
     },
     {
+      "id": "x-ai/grok-4.20-beta",
+      "display_name": "Grok 4.20 Beta",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "openrouter",
+      "provider_model_id": "x-ai/grok-4.20-beta",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "openrouter_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "xai/grok-4-20-beta",
+        "x-ai/grok-4-20-beta",
+        "x-ai/grok-4.20",
+        "grok-4.20-beta",
+        "grok-4-20-beta",
+        "grok-4.20",
+        "grok-4-20",
+        "grok-4.2",
+        "grok-4-2"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": null,
+      "max_output_tokens": null,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "0.000002",
+        "cached_input_usd": "2E-7",
+        "output_usd": "0.000006",
+        "reasoning_output_usd": "0.000006",
+        "source": "openrouter_catalog",
+        "observed_at": "2026-05-04"
+      }
+    },
+    {
       "id": "moonshotai/kimi-k2.6",
       "display_name": "Kimi K2.6",
       "display_group": "additional_first_launch",
@@ -255,11 +469,6 @@
       "compute_pool_kind": "api_proxy_pool",
       "compute_pool_id": "openrouter_pool",
       "route_kind": "api_proxy_pool",
-      "provider_domicile": "us",
-      "route_regions": [
-        "us"
-      ],
-      "zdr_supported": true,
       "harnesses": [
         "opencode_sdk"
       ],
@@ -286,44 +495,143 @@
       }
     },
     {
-      "id": "baseten/zai-org/GLM-5.2",
-      "display_name": "GLM 5.2 (Baseten)",
-      "display_group": "standard_baseten_direct",
+      "id": "arcee-ai/trinity-large-thinking",
+      "display_name": "Trinity Large Thinking",
+      "display_group": "additional_first_launch",
       "public": true,
-      "provider": "baseten",
-      "provider_model_id": "zai-org/GLM-5.2",
+      "provider": "openrouter",
+      "provider_model_id": "arcee-ai/trinity-large-thinking",
       "compute_pool_kind": "api_proxy_pool",
-      "compute_pool_id": "baseten_api_pool",
+      "compute_pool_id": "openrouter_pool",
       "route_kind": "api_proxy_pool",
-      "provider_domicile": "us",
-      "route_regions": [
-        "us"
-      ],
-      "zdr_supported": true,
       "harnesses": [
-        "codex",
         "opencode_sdk"
       ],
       "aliases": [
-        "zai-org/GLM-5.2",
-        "glm-5.2",
-        "baseten-glm-5.2"
+        "trinity-large-thinking",
+        "arcee/trinity-large-thinking",
+        "opencode-trinity-large-thinking"
       ],
       "supported_reasoning_efforts": [],
       "default_reasoning_effort": null,
       "context_window_tokens": 262144,
-      "max_output_tokens": 131072,
+      "max_output_tokens": 80000,
       "usage_required": true,
       "pricing_present": true,
       "pricing": {
         "currency": "USD",
         "unit": "token",
-        "input_usd": "0.0000015",
-        "cached_input_usd": "3E-7",
-        "output_usd": "0.0000045",
-        "reasoning_output_usd": "0.0000045",
-        "source": "baseten_model_api_pricing",
-        "observed_at": "2026-06-23"
+        "input_usd": "2.2E-7",
+        "cached_input_usd": "6E-8",
+        "output_usd": "8.5E-7",
+        "reasoning_output_usd": "8.5E-7",
+        "source": "openrouter_catalog",
+        "observed_at": "2026-05-23"
+      }
+    },
+    {
+      "id": "arcee-ai/trinity-large-thinking:free",
+      "display_name": "Trinity Large Thinking (free promo)",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "openrouter",
+      "provider_model_id": "arcee-ai/trinity-large-thinking:free",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "openrouter_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "trinity-large-thinking:free",
+        "arcee/trinity-large-thinking:free",
+        "opencode-trinity-large-thinking-free"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": 262144,
+      "max_output_tokens": 80000,
+      "usage_required": false,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "0",
+        "cached_input_usd": "0",
+        "output_usd": "0",
+        "reasoning_output_usd": "0",
+        "source": "openrouter_free_promo",
+        "observed_at": "2026-05-23"
+      }
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash",
+      "display_name": "DeepSeek V4 Flash",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "openrouter",
+      "provider_model_id": "deepseek/deepseek-v4-flash",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "openrouter_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "openrouter-deepseek-v4-flash",
+        "openrouter/deepseek-v4-flash",
+        "deepseek-v4-flash-openrouter"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": null,
+      "max_output_tokens": 32768,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "1.4E-7",
+        "cached_input_usd": "2.8E-8",
+        "output_usd": "2.8E-7",
+        "reasoning_output_usd": "2.8E-7",
+        "source": "openrouter_catalog",
+        "observed_at": "2026-05-11"
+      }
+    },
+    {
+      "id": "deepseek/deepseek-v4-pro",
+      "display_name": "DeepSeek V4 Pro",
+      "display_group": "additional_first_launch",
+      "public": true,
+      "provider": "openrouter",
+      "provider_model_id": "deepseek/deepseek-v4-pro",
+      "compute_pool_kind": "api_proxy_pool",
+      "compute_pool_id": "openrouter_pool",
+      "route_kind": "api_proxy_pool",
+      "harnesses": [
+        "opencode_sdk"
+      ],
+      "aliases": [
+        "openrouter-deepseek-v4-pro",
+        "openrouter/deepseek-v4-pro",
+        "deepseek-v4-pro-openrouter"
+      ],
+      "supported_reasoning_efforts": [],
+      "default_reasoning_effort": null,
+      "context_window_tokens": null,
+      "max_output_tokens": 32768,
+      "usage_required": true,
+      "pricing_present": true,
+      "pricing": {
+        "currency": "USD",
+        "unit": "token",
+        "input_usd": "4.35E-7",
+        "cached_input_usd": "3.625E-9",
+        "output_usd": "8.7E-7",
+        "reasoning_output_usd": "8.7E-7",
+        "source": "openrouter_catalog",
+        "observed_at": "2026-05-12"
       }
     }
   ]

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -480,6 +480,371 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FreeTierUsageResponse'
+  /api/v1/synth/models:
+    get:
+      tags:
+      - synth
+      summary: List Synth Models
+      operationId: list_synth_models_api_v1_synth_models_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response List Synth Models Api V1 Synth Models Get
+  /api/v1/stack-aux/usage:
+    get:
+      tags:
+      - stack-aux
+      summary: Get Stack Aux Usage
+      operationId: get_stack_aux_usage_api_v1_stack_aux_usage_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/v1/stack-aux/openai/v1/responses:
+    post:
+      tags:
+      - stack-aux
+      summary: Stack Aux Create Response
+      operationId: stack_aux_create_response_api_v1_stack_aux_openai_v1_responses_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/v1/stack-inference/usage:
+    get:
+      tags:
+      - stack-inference
+      summary: Get Stack Inference Usage
+      operationId: get_stack_inference_usage_api_v1_stack_inference_usage_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/v1/stack-inference/openai/v1/responses:
+    post:
+      tags:
+      - stack-inference
+      summary: Stack Inference Create Response
+      operationId: stack_inference_create_response_api_v1_stack_inference_openai_v1_responses_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/v1/growth/cta-events:
+    post:
+      tags:
+      - growth
+      summary: Record Growth Cta Event
+      operationId: record_growth_cta_event_api_v1_growth_cta_events_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrowthCtaEventRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrowthCtaEventResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/growth/funnel-events/ready:
+    get:
+      tags:
+      - growth
+      summary: Growth Funnel Events Ready
+      operationId: growth_funnel_events_ready_api_v1_growth_funnel_events_ready_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  anyOf:
+                  - type: string
+                  - type: boolean
+                type: object
+                title: Response Growth Funnel Events Ready Api V1 Growth Funnel Events
+                  Ready Get
+  /api/v1/growth/funnel-events:
+    post:
+      tags:
+      - growth
+      summary: Record Growth Funnel Event
+      operationId: record_growth_funnel_event_api_v1_growth_funnel_events_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrowthFunnelEventRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrowthFunnelEventResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/growth/funnel/{product}:
+    get:
+      tags:
+      - growth
+      summary: Growth Funnel Product Rollup
+      operationId: growth_funnel_product_rollup_api_v1_growth_funnel__product__get
+      parameters:
+      - name: product
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Product
+      - name: window_days
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 30
+          title: Window Days
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Growth Funnel Product Rollup Api V1 Growth Funnel  Product  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/product/stack-crashes/ready:
+    get:
+      tags:
+      - product
+      summary: Stack Crash Reports Ready
+      operationId: stack_crash_reports_ready_api_v1_product_stack_crashes_ready_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  anyOf:
+                  - type: string
+                  - type: boolean
+                type: object
+                title: Response Stack Crash Reports Ready Api V1 Product Stack Crashes
+                  Ready Get
+  /api/v1/product/stack-usage-events/ready:
+    get:
+      tags:
+      - product
+      summary: Stack Usage Events Ready
+      operationId: stack_usage_events_ready_api_v1_product_stack_usage_events_ready_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  anyOf:
+                  - type: string
+                  - type: boolean
+                type: object
+                title: Response Stack Usage Events Ready Api V1 Product Stack Usage
+                  Events Ready Get
+  /api/v1/product/stack-usage-events:
+    post:
+      tags:
+      - product
+      summary: Record Stack Usage Events
+      operationId: record_stack_usage_events_api_v1_product_stack_usage_events_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StackUsageEventsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackUsageEventsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/product/stack-crashes:
+    post:
+      tags:
+      - product
+      summary: Record Stack Client Crash
+      operationId: record_stack_client_crash_api_v1_product_stack_crashes_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StackCrashReportRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackCrashReportResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - product
+      summary: List Stack Crash Reports
+      operationId: list_stack_crash_reports_api_v1_product_stack_crashes_get
+      parameters:
+      - name: crash_class
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Crash Class
+      - name: surface
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Surface
+      - name: version
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Version
+      - name: window_days
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 365
+          minimum: 1
+          default: 30
+          title: Window Days
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackCrashReportListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/product/stack-crashes/summary:
+    get:
+      tags:
+      - product
+      summary: Stack Crash Reports Summary
+      operationId: stack_crash_reports_summary_api_v1_product_stack_crashes_summary_get
+      parameters:
+      - name: window_days
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 365
+          minimum: 1
+          default: 7
+          title: Window Days
+      - name: recent_limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 50
+          minimum: 1
+          default: 10
+          title: Recent Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackCrashReportSummaryResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/usage:
     get:
       tags:
@@ -2474,165 +2839,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/optimizers/runs/{run_id}/smr-optimizer-events/stream:
-    get:
-      tags:
-      - optimizers
-      summary: Stream Optimizer Smr Optimizer Events
-      operationId: stream_optimizer_smr_optimizer_events_api_v1_optimizers_runs__run_id__smr_optimizer_events_stream_get
-      parameters:
-      - name: run_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Run Id
-      - name: after_seq
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          default: 0
-          title: After Seq
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 5000
-          minimum: 1
-          default: 500
-          title: Limit
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/optimizers/runs/{run_id}/smr-optimizer-events:
-    get:
-      tags:
-      - optimizers
-      summary: Get Optimizer Smr Optimizer Events
-      operationId: get_optimizer_smr_optimizer_events_api_v1_optimizers_runs__run_id__smr_optimizer_events_get
-      parameters:
-      - name: run_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Run Id
-      - name: after_seq
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          default: 0
-          title: After Seq
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 5000
-          minimum: 1
-          default: 500
-          title: Limit
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/optimizers/runs/{run_id}/smr-optimizer-integrity:
-    get:
-      tags:
-      - optimizers
-      summary: Get Optimizer Smr Optimizer Integrity
-      operationId: get_optimizer_smr_optimizer_integrity_api_v1_optimizers_runs__run_id__smr_optimizer_integrity_get
-      parameters:
-      - name: run_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Run Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/optimizers/runs/{run_id}/smr-optimizer-checkpoints:
-    get:
-      tags:
-      - optimizers
-      summary: Get Optimizer Smr Optimizer Checkpoints
-      operationId: get_optimizer_smr_optimizer_checkpoints_api_v1_optimizers_runs__run_id__smr_optimizer_checkpoints_get
-      parameters:
-      - name: run_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Run Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/optimizers/runs/{run_id}/smr-optimizer-proof:
-    get:
-      tags:
-      - optimizers
-      summary: Get Optimizer Smr Optimizer Proof
-      operationId: get_optimizer_smr_optimizer_proof_api_v1_optimizers_runs__run_id__smr_optimizer_proof_get
-      parameters:
-      - name: run_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Run Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/optimizers/runs/{run_id}/cancel:
     post:
       tags:
@@ -2929,6 +3135,39 @@ paths:
                 additionalProperties: true
                 title: Response Publish Runtime Wakeup Smr Runtime Control Runtime
                   Publish Wakeup Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/runtime/control/mcp/call_tool:
+    post:
+      summary: Call Runtime Mcp Tool
+      operationId: call_runtime_mcp_tool_smr_runtime_control_mcp_call_tool_post
+      parameters:
+      - name: X-SMR-Worker-Key
+        in: header
+        required: true
+        schema:
+          type: string
+          title: X-Smr-Worker-Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuntimeMcpToolCallRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Call Runtime Mcp Tool Smr Runtime Control Mcp Call
+                  Tool Post
         '422':
           description: Validation Error
           content:
@@ -3295,7 +3534,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SmrProjectResponse'
-                title: Response List Projects
+                title: Response List Projects Smr Projects Get
         '422':
           description: Validation Error
           content:
@@ -4852,6 +5091,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /smr/billing/dev-environments/{dev_environment_id}/drawdown:
+    get:
+      tags:
+      - smr
+      - billing
+      summary: Get Dev Environment Billing Drawdown
+      operationId: get_dev_environment_billing_drawdown_smr_billing_dev_environments__dev_environment_id__drawdown_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmrBillingDrawdownResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/billing/dev-environments/{dev_environment_id}/preflight:
+    post:
+      tags:
+      - smr
+      - billing
+      summary: Preflight Dev Environment Billing
+      operationId: preflight_dev_environment_billing_smr_billing_dev_environments__dev_environment_id__preflight_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrDevEnvironmentBillingPreflightRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmrBillingPreflightResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /smr/billing/factory-efforts/{factory_effort_id}/drawdown:
     get:
       tags:
@@ -5958,6 +6259,623 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SmrProjectModelExportResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments:
+    get:
+      tags:
+      - smr
+      summary: List Dev Environments
+      operationId: list_dev_environments_smr_dev_environments_get
+      parameters:
+      - name: project_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Project Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DevEnvironmentResponse'
+                title: Response List Dev Environments Smr Dev Environments Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - smr
+      summary: Create Dev Environment
+      operationId: create_dev_environment_smr_dev_environments_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentCreateRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/topologies:
+    get:
+      tags:
+      - smr
+      summary: List Dev Environment Topologies
+      operationId: list_dev_environment_topologies_smr_dev_environments_topologies_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/EnvironmentTopologyResponse'
+                type: array
+                title: Response List Dev Environment Topologies Smr Dev Environments
+                  Topologies Get
+  /smr/dev-environments/topologies/{topology_id}:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Topology
+      operationId: get_dev_environment_topology_smr_dev_environments_topologies__topology_id__get
+      parameters:
+      - name: topology_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Topology Id
+      - name: version
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvironmentTopologyResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/materialization-queue:
+    get:
+      tags:
+      - smr
+      summary: List Dev Environment Materialization Queue
+      operationId: list_dev_environment_materialization_queue_smr_dev_environments_materialization_queue_get
+      parameters:
+      - name: project_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Project Id
+      - name: host_kind
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Host Kind
+      - name: backend_target
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Backend Target
+      - name: worker_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Worker Id
+      - name: include_leased
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Include Leased
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentMaterializationQueueResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment
+      operationId: get_dev_environment_smr_dev_environments__dev_environment_id__get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - smr
+      summary: Delete Dev Environment
+      operationId: delete_dev_environment_smr_dev_environments__dev_environment_id__delete
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/materialization-lease:
+    post:
+      tags:
+      - smr
+      summary: Claim Dev Environment Materialization
+      operationId: claim_dev_environment_materialization_smr_dev_environments__dev_environment_id__materialization_lease_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentMaterializationLeaseRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentMaterializationWorkItemResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/preflight:
+    post:
+      tags:
+      - smr
+      summary: Preflight Dev Environment
+      operationId: preflight_dev_environment_smr_dev_environments__dev_environment_id__preflight_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentPreflightResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/deploy:
+    post:
+      tags:
+      - smr
+      summary: Deploy Dev Environment
+      operationId: deploy_dev_environment_smr_dev_environments__dev_environment_id__deploy_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentActionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/start:
+    post:
+      tags:
+      - smr
+      summary: Start Dev Environment
+      operationId: start_dev_environment_smr_dev_environments__dev_environment_id__start_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentActionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/stop:
+    post:
+      tags:
+      - smr
+      summary: Stop Dev Environment
+      operationId: stop_dev_environment_smr_dev_environments__dev_environment_id__stop_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentStopRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/snapshot:
+    post:
+      tags:
+      - smr
+      summary: Snapshot Dev Environment
+      operationId: snapshot_dev_environment_smr_dev_environments__dev_environment_id__snapshot_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentActionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/materialization:
+    post:
+      tags:
+      - smr
+      summary: Report Dev Environment Materialization
+      operationId: report_dev_environment_materialization_smr_dev_environments__dev_environment_id__materialization_post
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevEnvironmentMaterializationReportRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/services:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Services
+      operationId: get_dev_environment_services_smr_dev_environments__dev_environment_id__services_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentServicesResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/attach:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Attach
+      operationId: get_dev_environment_attach_smr_dev_environments__dev_environment_id__attach_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentAttachResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/logs:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Logs
+      operationId: get_dev_environment_logs_smr_dev_environments__dev_environment_id__logs_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentLogsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/runs:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Runs
+      operationId: get_dev_environment_runs_smr_dev_environments__dev_environment_id__runs_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentRunsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/usage:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Usage
+      operationId: get_dev_environment_usage_smr_dev_environments__dev_environment_id__usage_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentUsageResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/dev-environments/{dev_environment_id}/receipts:
+    get:
+      tags:
+      - smr
+      summary: Get Dev Environment Receipts
+      operationId: get_dev_environment_receipts_smr_dev_environments__dev_environment_id__receipts_get
+      parameters:
+      - name: dev_environment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dev Environment Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevEnvironmentReceiptsResponse'
         '422':
           description: Validation Error
           content:
@@ -9476,7 +10394,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SmrRunResponse'
-                title: Response List Runs
+                title: Response List Runs Smr Runs Get
         '422':
           description: Validation Error
           content:
@@ -9571,7 +10489,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SmrRunResponse'
-                title: Response List Jobs
+                title: Response List Jobs Smr Jobs Get
         '422':
           description: Validation Error
           content:
@@ -10255,6 +11173,15 @@ paths:
           title: Include
         description: Temporary compatibility option. Set include=run for the legacy
           full run payload.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - type: object
+                additionalProperties: true
+              - type: 'null'
+              title: Stop Request
       responses:
         '200':
           description: Successful Response
@@ -10346,7 +11273,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SmrRunResponse'
-                title: Response List Project Runs
+                title: Response List Project Runs Smr Projects  Project Id  Runs Get
         '422':
           description: Validation Error
           content:
@@ -10375,7 +11302,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SmrRunResponse'
-                title: Response List Project Active Runs
+                title: Response List Project Active Runs Smr Projects  Project Id  Runs
+                  Active Get
         '422':
           description: Validation Error
           content:
@@ -11474,6 +12402,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /smr/runs/{run_id}/hosted-artifact:
+    get:
+      tags:
+      - smr
+      summary: Get Run Hosted Artifact
+      description: Return hosted artifact status + URLs for Stack operator surface
+        (AC-ORART-P5).
+      operationId: get_run_hosted_artifact_smr_runs__run_id__hosted_artifact_get
+      parameters:
+      - name: run_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Run Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Run Hosted Artifact Smr Runs  Run Id  Hosted Artifact
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /smr/projects/{project_id}/runs/{run_id}/ticks:
     post:
       tags:
@@ -11828,6 +12787,15 @@ paths:
           title: Include
         description: Temporary compatibility option. Set include=run for the legacy
           full run payload.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - type: object
+                additionalProperties: true
+              - type: 'null'
+              title: Stop Request
       responses:
         '200':
           description: Successful Response
@@ -11839,6 +12807,344 @@ paths:
                 - $ref: '#/components/schemas/SmrRunResponse'
                 title: Response Stop Project Run Smr Projects  Project Id  Runs  Run
                   Id  Stop Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/hosted-artifacts:
+    post:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Create Hosted Artifact
+      operationId: create_hosted_artifact_smr_hosted_artifacts_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrCreateHostedArtifactRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Create Hosted Artifact Smr Hosted Artifacts Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: List Hosted Artifacts
+      operationId: list_hosted_artifacts_smr_hosted_artifacts_get
+      parameters:
+      - name: project_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Project Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response List Hosted Artifacts Smr Hosted Artifacts Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/projects/{project_id}/hosted-artifacts:
+    get:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: List Project Hosted Artifacts
+      operationId: list_project_hosted_artifacts_smr_projects__project_id__hosted_artifacts_get
+      parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Project Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response List Project Hosted Artifacts Smr Projects  Project
+                  Id  Hosted Artifacts Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/hosted-artifacts/{hosted_artifact_id}:
+    get:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Get Hosted Artifact
+      operationId: get_hosted_artifact_smr_hosted_artifacts__hosted_artifact_id__get
+      parameters:
+      - name: hosted_artifact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Hosted Artifact Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Hosted Artifact Smr Hosted Artifacts  Hosted Artifact
+                  Id  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Patch Hosted Artifact
+      operationId: patch_hosted_artifact_smr_hosted_artifacts__hosted_artifact_id__patch
+      parameters:
+      - name: hosted_artifact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Hosted Artifact Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrPatchHostedArtifactRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Patch Hosted Artifact Smr Hosted Artifacts  Hosted
+                  Artifact Id  Patch
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Delete Hosted Artifact
+      operationId: delete_hosted_artifact_smr_hosted_artifacts__hosted_artifact_id__delete
+      parameters:
+      - name: hosted_artifact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Hosted Artifact Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Hosted Artifact Smr Hosted Artifacts  Hosted
+                  Artifact Id  Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/hosted-artifacts/{hosted_artifact_id}/content:
+    get:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Get Hosted Artifact Content
+      operationId: get_hosted_artifact_content_smr_hosted_artifacts__hosted_artifact_id__content_get
+      parameters:
+      - name: hosted_artifact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Hosted Artifact Id
+      - name: v
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: V
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/hosted-artifacts/{hosted_artifact_id}/publish-public:
+    post:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Publish Hosted Artifact Public
+      operationId: publish_hosted_artifact_public_smr_hosted_artifacts__hosted_artifact_id__publish_public_post
+      parameters:
+      - name: hosted_artifact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Hosted Artifact Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrPublishPublicArtifactRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Publish Hosted Artifact Public Smr Hosted Artifacts  Hosted
+                  Artifact Id  Publish Public Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/hosted-artifacts/{hosted_artifact_id}/assign-reviewer:
+    post:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Assign Hosted Artifact Reviewer
+      operationId: assign_hosted_artifact_reviewer_smr_hosted_artifacts__hosted_artifact_id__assign_reviewer_post
+      parameters:
+      - name: hosted_artifact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Hosted Artifact Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrAssignArtifactReviewerRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Assign Hosted Artifact Reviewer Smr Hosted Artifacts  Hosted
+                  Artifact Id  Assign Reviewer Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/public/artifacts/{slug}/pageview:
+    post:
+      tags:
+      - smr
+      - hosted-artifacts
+      summary: Record Public Artifact Pageview
+      operationId: record_public_artifact_pageview_smr_public_artifacts__slug__pageview_post
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrRecordArtifactPageviewRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Record Public Artifact Pageview Smr Public Artifacts  Slug  Pageview
+                  Post
         '422':
           description: Validation Error
           content:
@@ -17104,6 +18410,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /smr/admin/stack-aux/usage-rollup:
+    get:
+      tags:
+      - smr-admin
+      summary: Admin Get Stack Aux Usage Rollup
+      description: 'Firm-wide Stack aux (Nemotron Ultra) inference usage rollup.
+
+
+        Aggregates the append-only ``smr_spend_ledger`` rows written by the Stack
+        aux
+
+        inference proxy (``provider=''stack_aux''``, ``meter_kind=''stack_aux_inference''``)
+
+        into a per-day, per-model view: requests, tokens, cost, and distinct active
+
+        orgs. This is the firm-level "Nemotron Ultra served" read model.'
+      operationId: admin_get_stack_aux_usage_rollup_smr_admin_stack_aux_usage_rollup_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: days
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 365
+          minimum: 1
+          default: 30
+          title: Days
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Admin Get Stack Aux Usage Rollup Smr Admin Stack Aux
+                  Usage Rollup Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /smr/admin/runs/{run_id}/logs:
     get:
       tags:
@@ -20820,7 +22171,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Environments
-      operationId: proxy_environments_api_managed_agents_anthropic_v1_environments_post
+      operationId: proxy_environments_api_managed_agents_anthropic_v1_environments_get
       responses:
         '200':
           description: Successful Response
@@ -20831,7 +22182,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Environments
-      operationId: proxy_environments_api_managed_agents_anthropic_v1_environments_post__post__1
+      operationId: proxy_environments_api_managed_agents_anthropic_v1_environments_get__post__1
       responses:
         '200':
           description: Successful Response
@@ -20843,7 +22194,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Environments Environment Id
-      operationId: proxy_environments_environment_id_api_managed_agents_anthropic_v1_environments__environment_id__post
+      operationId: proxy_environments_environment_id_api_managed_agents_anthropic_v1_environments__environment_id__get
       responses:
         '200':
           description: Successful Response
@@ -20854,7 +22205,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Environments Environment Id
-      operationId: proxy_environments_environment_id_api_managed_agents_anthropic_v1_environments__environment_id__post__post__1
+      operationId: proxy_environments_environment_id_api_managed_agents_anthropic_v1_environments__environment_id__get__post__1
       responses:
         '200':
           description: Successful Response
@@ -20878,7 +22229,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Agents
-      operationId: proxy_agents_api_managed_agents_anthropic_v1_agents_post
+      operationId: proxy_agents_api_managed_agents_anthropic_v1_agents_get
       responses:
         '200':
           description: Successful Response
@@ -20889,7 +22240,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Agents
-      operationId: proxy_agents_api_managed_agents_anthropic_v1_agents_post__post__1
+      operationId: proxy_agents_api_managed_agents_anthropic_v1_agents_get__post__1
       responses:
         '200':
           description: Successful Response
@@ -20901,7 +22252,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Agents Agent Id
-      operationId: proxy_agents_agent_id_api_managed_agents_anthropic_v1_agents__agent_id__post
+      operationId: proxy_agents_agent_id_api_managed_agents_anthropic_v1_agents__agent_id__get
       responses:
         '200':
           description: Successful Response
@@ -20912,7 +22263,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Agents Agent Id
-      operationId: proxy_agents_agent_id_api_managed_agents_anthropic_v1_agents__agent_id__post__post__1
+      operationId: proxy_agents_agent_id_api_managed_agents_anthropic_v1_agents__agent_id__get__post__1
       responses:
         '200':
           description: Successful Response
@@ -20936,7 +22287,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Sessions
-      operationId: proxy_sessions_api_managed_agents_anthropic_v1_sessions_post
+      operationId: proxy_sessions_api_managed_agents_anthropic_v1_sessions_get
       responses:
         '200':
           description: Successful Response
@@ -20947,7 +22298,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Sessions
-      operationId: proxy_sessions_api_managed_agents_anthropic_v1_sessions_post__post__1
+      operationId: proxy_sessions_api_managed_agents_anthropic_v1_sessions_get__post__1
       responses:
         '200':
           description: Successful Response
@@ -20959,7 +22310,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Sessions Session Id
-      operationId: proxy_sessions_session_id_api_managed_agents_anthropic_v1_sessions__session_id__post
+      operationId: proxy_sessions_session_id_api_managed_agents_anthropic_v1_sessions__session_id__get
       responses:
         '200':
           description: Successful Response
@@ -20970,7 +22321,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Sessions Session Id
-      operationId: proxy_sessions_session_id_api_managed_agents_anthropic_v1_sessions__session_id__post__post__1
+      operationId: proxy_sessions_session_id_api_managed_agents_anthropic_v1_sessions__session_id__get__post__1
       responses:
         '200':
           description: Successful Response
@@ -20994,7 +22345,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Sessions Session Id Events
-      operationId: proxy_sessions_session_id_events_api_managed_agents_anthropic_v1_sessions__session_id__events_post
+      operationId: proxy_sessions_session_id_events_api_managed_agents_anthropic_v1_sessions__session_id__events_get
       responses:
         '200':
           description: Successful Response
@@ -21005,7 +22356,7 @@ paths:
       tags:
       - managed-agents-anthropic-proxy
       summary: Proxy Sessions Session Id Events
-      operationId: proxy_sessions_session_id_events_api_managed_agents_anthropic_v1_sessions__session_id__events_post__post__1
+      operationId: proxy_sessions_session_id_events_api_managed_agents_anthropic_v1_sessions__session_id__events_get__post__1
       responses:
         '200':
           description: Successful Response
@@ -21053,7 +22404,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Responses Response Id
-      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__delete
+      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__get
       responses:
         '200':
           description: Successful Response
@@ -21064,7 +22415,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Responses Response Id
-      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__delete__delete__1
+      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__get__delete__1
       responses:
         '200':
           description: Successful Response
@@ -21136,7 +22487,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id
-      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__post
+      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__get
       responses:
         '200':
           description: Successful Response
@@ -21147,7 +22498,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id
-      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__post__post__1
+      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__get__post__1
       responses:
         '200':
           description: Successful Response
@@ -21158,7 +22509,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id
-      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__post__delete__2
+      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__get__delete__2
       responses:
         '200':
           description: Successful Response
@@ -21170,7 +22521,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id Items
-      operationId: proxy_openai_conversations_conversation_id_items_api_managed_agents_openai_v1_conversations__conversation_id__items_post
+      operationId: proxy_openai_conversations_conversation_id_items_api_managed_agents_openai_v1_conversations__conversation_id__items_get
       responses:
         '200':
           description: Successful Response
@@ -21181,7 +22532,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id Items
-      operationId: proxy_openai_conversations_conversation_id_items_api_managed_agents_openai_v1_conversations__conversation_id__items_post__post__1
+      operationId: proxy_openai_conversations_conversation_id_items_api_managed_agents_openai_v1_conversations__conversation_id__items_get__post__1
       responses:
         '200':
           description: Successful Response
@@ -21193,7 +22544,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id Items Item Id
-      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__delete
+      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__get
       responses:
         '200':
           description: Successful Response
@@ -21204,7 +22555,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id Items Item Id
-      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__delete__delete__1
+      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__get__delete__1
       responses:
         '200':
           description: Successful Response
@@ -21238,71 +22589,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/GeloLaunchPromoStatusResponse'
   /s/{route_token}/{path}:
-    post:
-      tags:
-      - synthtunnel-public
-      summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post
-      parameters:
-      - name: route_token
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Route Token
-      - name: path
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
     options:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__options__1
-      parameters:
-      - name: route_token
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Route Token
-      - name: path
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    delete:
-      tags:
-      - synthtunnel-public
-      summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__delete__2
+      operationId: synthtunnel_gateway_s__route_token___path__options
       parameters:
       - name: route_token
         in: path
@@ -21332,7 +22623,7 @@ paths:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__get__3
+      operationId: synthtunnel_gateway_s__route_token___path__options__get__1
       parameters:
       - name: route_token
         in: path
@@ -21358,11 +22649,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-    put:
+    post:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__put__4
+      operationId: synthtunnel_gateway_s__route_token___path__options__post__2
       parameters:
       - name: route_token
         in: path
@@ -21392,7 +22683,67 @@ paths:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__patch__5
+      operationId: synthtunnel_gateway_s__route_token___path__options__patch__3
+      parameters:
+      - name: route_token
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Route Token
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - synthtunnel-public
+      summary: Synthtunnel Gateway
+      operationId: synthtunnel_gateway_s__route_token___path__options__delete__4
+      parameters:
+      - name: route_token
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Route Token
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - synthtunnel-public
+      summary: Synthtunnel Gateway
+      operationId: synthtunnel_gateway_s__route_token___path__options__put__5
       parameters:
       - name: route_token
         in: path
@@ -22151,7 +23502,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/app__api__v1__admin__UsageSummaryResponse'
+                $ref: '#/components/schemas/UsageSummaryResponse'
         '422':
           description: Validation Error
           content:
@@ -23318,6 +24669,76 @@ paths:
           content:
             application/json:
               schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/open-research/v1/artifacts:
+    get:
+      tags:
+      - open-research-public
+      summary: List Public Artifacts
+      operationId: list_public_artifacts_api_open_research_v1_artifacts_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response List Public Artifacts Api Open Research V1 Artifacts
+                  Get
+  /api/open-research/v1/artifacts/{slug}:
+    get:
+      tags:
+      - open-research-public
+      summary: Get Public Artifact
+      operationId: get_public_artifact_api_open_research_v1_artifacts__slug__get
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Public Artifact Api Open Research V1 Artifacts  Slug  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/open-research/v1/artifact-pages/{slug}:
+    get:
+      tags:
+      - open-research-public
+      summary: Get Public Artifact Page
+      operationId: get_public_artifact_page_api_open_research_v1_artifact_pages__slug__get
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
         '422':
           description: Validation Error
           content:
@@ -25172,6 +26593,13 @@ components:
       - resume
       - interrupt
       title: ActorControlAction
+    ActorResourceCapability:
+      type: string
+      enum:
+      - inference
+      - training
+      - model_artifact
+      title: ActorResourceCapability
     AddCreditsRequest:
       properties:
         org_id:
@@ -26354,6 +27782,553 @@ components:
       - deleted_at
       title: DeleteTunnelResponse
       description: Response when deleting a tunnel.
+    DevEnvironmentActionRequest:
+      properties:
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      title: DevEnvironmentActionRequest
+    DevEnvironmentAttachResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        lifecycle_state:
+          type: string
+          title: Lifecycle State
+        attachable:
+          type: boolean
+          title: Attachable
+          default: false
+        attach_surfaces:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Attach Surfaces
+        default_surface:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Default Surface
+        operator_next_action:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Operator Next Action
+        topology:
+          additionalProperties: true
+          type: object
+          title: Topology
+        service_summary:
+          additionalProperties: true
+          type: object
+          title: Service Summary
+        projection_sources:
+          additionalProperties:
+            type: string
+          type: object
+          title: Projection Sources
+      type: object
+      required:
+      - dev_environment_id
+      - lifecycle_state
+      title: DevEnvironmentAttachResponse
+    DevEnvironmentCreateRequest:
+      properties:
+        project_id:
+          type: string
+          title: Project Id
+        name:
+          type: string
+          title: Name
+        backend_target:
+          type: string
+          enum:
+          - dev
+          - staging
+          - prod
+          title: Backend Target
+          default: dev
+        topology_id:
+          type: string
+          title: Topology Id
+          default: synth-dev
+        topology_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Topology Version
+        environment_name:
+          type: string
+          title: Environment Name
+        environment_digest:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Environment Digest
+        host_kind:
+          type: string
+          title: Host Kind
+          default: daytona
+        quota_class:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Quota Class
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - project_id
+      - name
+      - environment_name
+      title: DevEnvironmentCreateRequest
+    DevEnvironmentLogsResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        lifecycle_state:
+          type: string
+          title: Lifecycle State
+        entries:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Entries
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      type: object
+      required:
+      - dev_environment_id
+      - lifecycle_state
+      title: DevEnvironmentLogsResponse
+    DevEnvironmentMaterializationLeaseRequest:
+      properties:
+        worker_id:
+          type: string
+          title: Worker Id
+        lease_seconds:
+          anyOf:
+          - type: integer
+            maximum: 3600.0
+            minimum: 30.0
+          - type: 'null'
+          title: Lease Seconds
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - worker_id
+      title: DevEnvironmentMaterializationLeaseRequest
+    DevEnvironmentMaterializationQueueResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/DevEnvironmentMaterializationWorkItemResponse'
+          type: array
+          title: Items
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      type: object
+      title: DevEnvironmentMaterializationQueueResponse
+    DevEnvironmentMaterializationReportRequest:
+      properties:
+        result:
+          type: string
+          enum:
+          - succeeded
+          - failed
+          - degraded
+          title: Result
+          default: succeeded
+        lifecycle_state:
+          anyOf:
+          - type: string
+            enum:
+            - deployed
+            - running
+            - stopped
+          - type: 'null'
+          title: Lifecycle State
+        service_summary:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Service Summary
+        log_entries:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Log Entries
+        receipt_refs:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Receipt Refs
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+        error:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Error
+      type: object
+      title: DevEnvironmentMaterializationReportRequest
+    DevEnvironmentMaterializationWorkItemResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        environment_id:
+          type: string
+          title: Environment Id
+        org_id:
+          type: string
+          title: Org Id
+        project_id:
+          type: string
+          title: Project Id
+        name:
+          type: string
+          title: Name
+        backend_target:
+          type: string
+          title: Backend Target
+        lifecycle_state:
+          type: string
+          title: Lifecycle State
+        materialization_action:
+          type: string
+          title: Materialization Action
+        topology_id:
+          type: string
+          title: Topology Id
+        topology_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Topology Version
+        host_kind:
+          type: string
+          title: Host Kind
+        environment:
+          additionalProperties: true
+          type: object
+          title: Environment
+        quota_class:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Quota Class
+        materialization_request:
+          additionalProperties: true
+          type: object
+          title: Materialization Request
+        materialization_lease:
+          additionalProperties: true
+          type: object
+          title: Materialization Lease
+        service_summary:
+          additionalProperties: true
+          type: object
+          title: Service Summary
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+        created_at:
+          title: Created At
+        updated_at:
+          title: Updated At
+      type: object
+      required:
+      - dev_environment_id
+      - environment_id
+      - org_id
+      - project_id
+      - name
+      - backend_target
+      - lifecycle_state
+      - materialization_action
+      - topology_id
+      - host_kind
+      - created_at
+      - updated_at
+      title: DevEnvironmentMaterializationWorkItemResponse
+    DevEnvironmentPreflightResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        preflight_ok:
+          type: boolean
+          title: Preflight Ok
+        lifecycle_state:
+          type: string
+          title: Lifecycle State
+        checks:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Checks
+        error:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Error
+        manifest:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Manifest
+        topology:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Topology
+      type: object
+      required:
+      - dev_environment_id
+      - preflight_ok
+      - lifecycle_state
+      title: DevEnvironmentPreflightResponse
+    DevEnvironmentReceiptsResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        lifecycle_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Lifecycle State
+        environment:
+          additionalProperties: true
+          type: object
+          title: Environment
+        usage:
+          additionalProperties: true
+          type: object
+          title: Usage
+        summary:
+          additionalProperties: true
+          type: object
+          title: Summary
+        receipts:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Receipts
+        projection_sources:
+          additionalProperties:
+            type: string
+          type: object
+          title: Projection Sources
+      type: object
+      required:
+      - dev_environment_id
+      title: DevEnvironmentReceiptsResponse
+    DevEnvironmentResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        environment_id:
+          type: string
+          title: Environment Id
+        org_id:
+          type: string
+          title: Org Id
+        project_id:
+          type: string
+          title: Project Id
+        name:
+          type: string
+          title: Name
+        backend_target:
+          type: string
+          title: Backend Target
+        lifecycle_state:
+          type: string
+          title: Lifecycle State
+        topology_id:
+          type: string
+          title: Topology Id
+        topology_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Topology Version
+        environment_name:
+          type: string
+          title: Environment Name
+        environment_digest:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Environment Digest
+        host_kind:
+          type: string
+          title: Host Kind
+        quota_class:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Quota Class
+        cost_summary:
+          additionalProperties: true
+          type: object
+          title: Cost Summary
+        service_summary:
+          additionalProperties: true
+          type: object
+          title: Service Summary
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+        created_by_user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Created By User Id
+        created_at:
+          title: Created At
+        updated_at:
+          title: Updated At
+        deleted_at:
+          anyOf:
+          - {}
+          - type: 'null'
+          title: Deleted At
+      type: object
+      required:
+      - dev_environment_id
+      - environment_id
+      - org_id
+      - project_id
+      - name
+      - backend_target
+      - lifecycle_state
+      - topology_id
+      - environment_name
+      - host_kind
+      - created_at
+      - updated_at
+      title: DevEnvironmentResponse
+    DevEnvironmentRunsResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        runs:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Runs
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      type: object
+      required:
+      - dev_environment_id
+      title: DevEnvironmentRunsResponse
+    DevEnvironmentServicesResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        lifecycle_state:
+          type: string
+          title: Lifecycle State
+        services:
+          additionalProperties: true
+          type: object
+          title: Services
+      type: object
+      required:
+      - dev_environment_id
+      - lifecycle_state
+      title: DevEnvironmentServicesResponse
+    DevEnvironmentStopRequest:
+      properties:
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+        decision:
+          type: string
+          enum:
+          - retain
+          - destroy
+          title: Decision
+          default: retain
+      type: object
+      title: DevEnvironmentStopRequest
+    DevEnvironmentUsageResponse:
+      properties:
+        dev_environment_id:
+          type: string
+          title: Dev Environment Id
+        summary:
+          additionalProperties: true
+          type: object
+          title: Summary
+        by_meter:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: By Meter
+        facts:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Facts
+        limit:
+          type: integer
+          title: Limit
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      type: object
+      required:
+      - dev_environment_id
+      - limit
+      title: DevEnvironmentUsageResponse
     EnqueueInitialRuntimeMessagesRequest:
       properties:
         run_id:
@@ -26708,6 +28683,66 @@ components:
       required:
       - label
       title: EnvironmentSecretSpec
+    EnvironmentTopologyResponse:
+      properties:
+        topology_id:
+          type: string
+          title: Topology Id
+        version:
+          type: string
+          title: Version
+        display_name:
+          type: string
+          title: Display Name
+        service_graph:
+          additionalProperties: true
+          type: object
+          title: Service Graph
+        backing_services:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Backing Services
+        manifest_refs:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Manifest Refs
+        required_secrets:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Required Secrets
+        network_surfaces:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Network Surfaces
+        health_checks:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Health Checks
+        allowed_substrates:
+          items:
+            type: string
+          type: array
+          title: Allowed Substrates
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - topology_id
+      - version
+      - display_name
+      title: EnvironmentTopologyResponse
     ExportTrainedModelBody:
       properties:
         destination:
@@ -27030,6 +29065,200 @@ components:
       - autumn_product_id
       - autumn_feature_id
       title: GeloLaunchPromoStatusResponse
+    GrowthCtaEventRequest:
+      properties:
+        event_name:
+          type: string
+          enum:
+          - cta_viewed
+          - cta_clicked
+          - destination_reached
+          - signup_initiated
+          - signup_completed
+          title: Event Name
+        campaign:
+          type: string
+          maxLength: 120
+          minLength: 1
+          title: Campaign
+        cta_id:
+          type: string
+          maxLength: 120
+          minLength: 1
+          title: Cta Id
+        cta_location:
+          type: string
+          maxLength: 120
+          minLength: 1
+          title: Cta Location
+        source_page:
+          type: string
+          maxLength: 512
+          minLength: 1
+          title: Source Page
+        source_page_type:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Source Page Type
+        product:
+          anyOf:
+          - type: string
+            maxLength: 120
+          - type: 'null'
+          title: Product
+        target_url:
+          anyOf:
+          - type: string
+            maxLength: 512
+          - type: 'null'
+          title: Target Url
+        referrer:
+          anyOf:
+          - type: string
+            maxLength: 512
+          - type: 'null'
+          title: Referrer
+        session_id:
+          anyOf:
+          - type: string
+            maxLength: 120
+          - type: 'null'
+          title: Session Id
+        client_event_id:
+          anyOf:
+          - type: string
+            maxLength: 160
+          - type: 'null'
+          title: Client Event Id
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - event_name
+      - campaign
+      - cta_id
+      - cta_location
+      - source_page
+      title: GrowthCtaEventRequest
+    GrowthCtaEventResponse:
+      properties:
+        event_id:
+          type: string
+          title: Event Id
+        status:
+          type: string
+          enum:
+          - recorded
+          - duplicate
+          title: Status
+      type: object
+      required:
+      - event_id
+      - status
+      title: GrowthCtaEventResponse
+    GrowthFunnelEventRequest:
+      properties:
+        event_name:
+          type: string
+          enum:
+          - cta_destination_reached
+          - signup_intent
+          - signup_completed
+          - skill_download_clicked
+          - docs_cta_clicked
+          - blog_cta_clicked
+          title: Event Name
+        correlation_id:
+          type: string
+          maxLength: 128
+          minLength: 8
+          title: Correlation Id
+        product:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Product
+        campaign_id:
+          anyOf:
+          - type: string
+            maxLength: 120
+          - type: 'null'
+          title: Campaign Id
+        utm_source:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Utm Source
+        utm_medium:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Utm Medium
+        utm_campaign:
+          anyOf:
+          - type: string
+            maxLength: 120
+          - type: 'null'
+          title: Utm Campaign
+        utm_content:
+          anyOf:
+          - type: string
+            maxLength: 160
+          - type: 'null'
+          title: Utm Content
+        growth_action_id:
+          anyOf:
+          - type: string
+            maxLength: 160
+          - type: 'null'
+          title: Growth Action Id
+        target_url:
+          anyOf:
+          - type: string
+            maxLength: 2048
+          - type: 'null'
+          title: Target Url
+        referrer_url:
+          anyOf:
+          - type: string
+            maxLength: 2048
+          - type: 'null'
+          title: Referrer Url
+        source_page_type:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Source Page Type
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - event_name
+      - correlation_id
+      title: GrowthFunnelEventRequest
+    GrowthFunnelEventResponse:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+        event_id:
+          type: string
+          title: Event Id
+      type: object
+      required:
+      - ok
+      - event_id
+      title: GrowthFunnelEventResponse
     HTTPValidationError:
       properties:
         detail:
@@ -28858,6 +31087,14 @@ components:
             maxLength: 64
           - type: 'null'
           title: Install Id
+        models:
+          items:
+            additionalProperties:
+              type: string
+            type: object
+          type: array
+          maxItems: 16
+          title: Models
       type: object
       required:
       - algorithm
@@ -30281,6 +32518,34 @@ components:
       - phase
       - readiness
       title: ProjectWorkspaceSummary
+    Provider:
+      type: string
+      enum:
+      - openrouter
+      - tinker
+      - synth_ai
+      - cursor
+      - deepseek
+      - xai
+      - groq
+      title: Provider
+    ProviderBinding:
+      properties:
+        provider:
+          $ref: '#/components/schemas/Provider'
+        config:
+          additionalProperties: true
+          type: object
+          title: Config
+        limit:
+          anyOf:
+          - $ref: '#/components/schemas/UsageLimit'
+          - type: 'null'
+      additionalProperties: false
+      type: object
+      required:
+      - provider
+      title: ProviderBinding
     ProviderUsed:
       type: string
       enum:
@@ -30596,110 +32861,6 @@ components:
       required:
       - credential_value
       title: ResolvedCredentialResponse
-    ResourceCapability:
-      type: string
-      enum:
-      - inference
-      - training
-      - model_artifact
-      title: ResourceCapability
-    ResourceProvider:
-      type: string
-      enum:
-      - openrouter
-      - tinker
-      - synth_ai
-      - cursor
-      - deepseek
-      - xai
-      - modal
-      - openai_chatgpt
-      - baseten
-      title: ResourceProvider
-    ResourceProviderBinding:
-      properties:
-        provider:
-          $ref: '#/components/schemas/ResourceProvider'
-        config:
-          additionalProperties: true
-          type: object
-          title: Config
-        limit:
-          anyOf:
-          - $ref: '#/components/schemas/UsageLimit'
-          - type: 'null'
-      additionalProperties: false
-      type: object
-      required:
-      - provider
-      title: ResourceProviderBinding
-    ResourceProviderPolicy:
-      properties:
-        default:
-          anyOf:
-          - $ref: '#/components/schemas/ResourceRoutingPolicy'
-          - type: 'null'
-        agent_inference:
-          anyOf:
-          - $ref: '#/components/schemas/ResourceRoutingPolicy'
-          - type: 'null'
-        experiment_inference:
-          anyOf:
-          - $ref: '#/components/schemas/ResourceRoutingPolicy'
-          - type: 'null'
-      additionalProperties: false
-      type: object
-      title: ResourceProviderPolicy
-    ResourceRoutingPolicy:
-      properties:
-        allowed_providers:
-          items:
-            type: string
-          type: array
-          title: Allowed Providers
-        denied_providers:
-          items:
-            type: string
-          type: array
-          title: Denied Providers
-        preferred_providers:
-          items:
-            type: string
-          type: array
-          title: Preferred Providers
-        allowed_models:
-          items:
-            type: string
-          type: array
-          title: Allowed Models
-        denied_models:
-          items:
-            type: string
-          type: array
-          title: Denied Models
-        preferred_models:
-          items:
-            type: string
-          type: array
-          title: Preferred Models
-        require_zdr:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          title: Require Zdr
-        allowed_domiciles:
-          items:
-            type: string
-          type: array
-          title: Allowed Domiciles
-        allowed_regions:
-          items:
-            type: string
-          type: array
-          title: Allowed Regions
-      additionalProperties: false
-      type: object
-      title: ResourceRoutingPolicy
     RotateTunnelRequest:
       properties:
         local_port:
@@ -31173,6 +33334,28 @@ components:
       - seq
       - action
       title: RuntimeIntentView
+    RuntimeMcpToolCallRequest:
+      properties:
+        run_id:
+          type: string
+          title: Run Id
+        namespace:
+          type: string
+          title: Namespace
+        tool_name:
+          type: string
+          title: Tool Name
+        arguments:
+          additionalProperties: true
+          type: object
+          title: Arguments
+          default: {}
+      type: object
+      required:
+      - run_id
+      - namespace
+      - tool_name
+      title: RuntimeMcpToolCallRequest
     RuntimeMessageMode:
       type: string
       enum:
@@ -31413,8 +33596,8 @@ components:
         actor_subtype:
           $ref: '#/components/schemas/SmrActorSubtype'
           description: Actor subtype. Supported values are main, engineer, researcher,
-            task_completion, run_completion, safety, objective; valid combinations
-            depend on actor_type.
+            artifact_builder, artifact_reviewer, task_completion, run_completion,
+            safety, objective, seraph, gardener; valid combinations depend on actor_type.
         agent_model:
           $ref: '#/components/schemas/SmrAgentModel'
           description: Actor-scoped agent model override. Engineer-only models such
@@ -31426,34 +33609,6 @@ components:
           - type: 'null'
           title: Agent Model Params
           description: Optional actor-scoped model params override.
-        agent_harness:
-          anyOf:
-          - type: string
-            enum:
-            - codex
-            - cursor
-            - opencode_sdk
-          - type: 'null'
-          title: Agent Harness
-          description: Optional actor-scoped harness override.
-        agent_kind:
-          anyOf:
-          - type: string
-            enum:
-            - codex
-            - cursor
-            - opencode_sdk
-          - type: 'null'
-          title: Agent Kind
-          description: Compatibility alias for agent_harness.
-        provider:
-          anyOf:
-          - additionalProperties: true
-            type: object
-          - type: 'null'
-          title: Provider
-          description: 'Optional actor-scoped provider requirement. Use {''provider_id'':
-            ''deepseek''} to require an approved profile for that provider.'
       additionalProperties: false
       type: object
       required:
@@ -31464,10 +33619,10 @@ components:
     SmrActorResourceEntry:
       properties:
         provider:
-          $ref: '#/components/schemas/ResourceProvider'
+          $ref: '#/components/schemas/Provider'
         capabilities:
           items:
-            $ref: '#/components/schemas/ResourceCapability'
+            $ref: '#/components/schemas/ActorResourceCapability'
           type: array
           title: Capabilities
         launch_enabled:
@@ -31712,10 +33867,14 @@ components:
       - main
       - engineer
       - researcher
+      - artifact_builder
+      - artifact_reviewer
       - task_completion
       - run_completion
       - safety
       - objective
+      - seraph
+      - gardener
       title: SmrActorSubtype
     SmrActorTraceArtifactRefResponse:
       properties:
@@ -32086,26 +34245,24 @@ components:
     SmrAgentModel:
       type: string
       enum:
-      - gpt-5-codex
       - gpt-5.3-codex
       - gpt-5.3-codex-spark
+      - gpt-5.4
       - gpt-5.5
       - gpt-5.4-mini
-      - nemotron-super
-      - deepseek/deepseek-v4-flash
-      - deepseek/deepseek-v4-pro
-      - cursor/composer-2.5
-      - cursor/gpt-5
-      - cursor/sonnet-4
+      - gpt-5.4-nano
+      - gpt-oss-120b
+      - anthropic/claude-sonnet-4-6
+      - anthropic/claude-haiku-4-5-20251001
+      - x-ai/grok-4.1-fast
       - x-ai/grok-4.3
       - x-ai/grok-build
+      - x-ai/grok-4.20-beta
       - moonshotai/kimi-k2.6
-      - baseten/zai-org/GLM-5.2
-      - modal/zai-org/GLM-5.2-FP8
-      - deepseek/deepseek-v4-flash-direct
-      - deepseek/deepseek-v4-pro-direct
-      - deepseek/deepseek-chat
-      - deepseek/deepseek-reasoner
+      - arcee-ai/trinity-large-thinking
+      - arcee-ai/trinity-large-thinking:free
+      - deepseek/deepseek-v4-flash
+      - deepseek/deepseek-v4-pro
       title: SmrAgentModel
     SmrAgentModelCatalogEntry:
       properties:
@@ -32433,6 +34590,23 @@ components:
       - url
       - abstract_text
       title: SmrArxivPaperSearchResultResponse
+    SmrAssignArtifactReviewerRequest:
+      properties:
+        reason:
+          type: string
+          maxLength: 2000
+          minLength: 1
+          title: Reason
+        summary:
+          anyOf:
+          - type: string
+            maxLength: 4000
+          - type: 'null'
+          title: Summary
+      type: object
+      required:
+      - reason
+      title: SmrAssignArtifactReviewerRequest
     SmrAuthorityReadoutsResponse:
       properties:
         project_id:
@@ -32670,6 +34844,11 @@ components:
           - type: string
           - type: 'null'
           title: Wallet Ledger Id
+        dev_environment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dev Environment Id
         breach_id:
           anyOf:
           - type: string
@@ -32702,6 +34881,11 @@ components:
           - type: string
           - type: 'null'
           title: Run Id
+        dev_environment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dev Environment Id
         factory_effort_id:
           anyOf:
           - type: string
@@ -32830,6 +35014,11 @@ components:
           - type: string
           - type: 'null'
           title: Run Id
+        dev_environment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dev Environment Id
         factory_effort_id:
           anyOf:
           - type: string
@@ -33031,6 +35220,58 @@ components:
       - supports_chatgpt_connect
       - supports_capacity_lane_preview
       title: SmrCapabilitiesResponse
+    SmrCreateHostedArtifactRequest:
+      properties:
+        hosted_artifact_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hosted Artifact Id
+        title:
+          type: string
+          maxLength: 500
+          minLength: 1
+          title: Title
+        html_content:
+          type: string
+          minLength: 1
+          title: Html Content
+        visibility:
+          type: string
+          maxLength: 20
+          title: Visibility
+          default: org
+        project_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Project Id
+        effort_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+        source_run_ids:
+          items:
+            type: string
+          type: array
+          title: Source Run Ids
+        trace_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Trace Id
+        slug_hint:
+          anyOf:
+          - type: string
+            maxLength: 120
+          - type: 'null'
+          title: Slug Hint
+      type: object
+      required:
+      - title
+      - html_content
+      title: SmrCreateHostedArtifactRequest
     SmrCredentialProvider:
       type: string
       enum:
@@ -33038,6 +35279,7 @@ components:
       - openai
       - openrouter
       - xai
+      - groq
       - tinker
       title: SmrCredentialProvider
     SmrCredentialRefCreateRequest:
@@ -33158,6 +35400,20 @@ components:
       - created_at
       - updated_at
       title: SmrCredentialRefResponse
+    SmrDevEnvironmentBillingPreflightRequest:
+      properties:
+        model_class:
+          $ref: '#/components/schemas/SmrModelClass'
+        estimated_customer_debit_microcents:
+          type: integer
+          minimum: 0.0
+          title: Estimated Customer Debit Microcents
+          default: 0
+      additionalProperties: false
+      type: object
+      required:
+      - model_class
+      title: SmrDevEnvironmentBillingPreflightRequest
     SmrDirectedEffortOutcomeInlineCreateRequest:
       properties:
         title:
@@ -35394,18 +37650,6 @@ components:
             format: date-time
           - type: 'null'
           title: Next Wake At
-        runtime:
-          additionalProperties: true
-          type: object
-          title: Runtime
-        proof_readiness:
-          additionalProperties: true
-          type: object
-          title: Proof Readiness
-        public_visuals:
-          additionalProperties: true
-          type: object
-          title: Public Visuals
         publication_states:
           additionalProperties: true
           type: object
@@ -36080,9 +38324,11 @@ components:
     SmrInferenceProvider:
       type: string
       enum:
+      - baseten
       - deepseek
       - openai
       - google
+      - groq
       - openrouter
       - xai
       title: SmrInferenceProvider
@@ -36150,17 +38396,6 @@ components:
           type: string
           title: Role
           default: dependency
-        split_role:
-          anyOf:
-          - type: string
-            enum:
-            - visible_train
-            - heldout
-          - type: 'null'
-          title: Split Role
-          description: Optimizer campaign split classification for benchmark resources.
-            Use visible_train for proposer/search-visible resources and heldout for
-            resources withheld until measurement.
         metadata:
           additionalProperties: true
           type: object
@@ -36463,14 +38698,25 @@ components:
             type: object
           type: array
           title: Providers
+        launch_mode:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Launch Mode
+        dev_environment:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Dev Environment
         capabilities:
           items:
-            $ref: '#/components/schemas/ResourceCapability'
+            $ref: '#/components/schemas/ActorResourceCapability'
           type: array
           title: Capabilities
         required_capabilities:
           items:
-            $ref: '#/components/schemas/ResourceCapability'
+            $ref: '#/components/schemas/ActorResourceCapability'
           type: array
           title: Required Capabilities
         limit:
@@ -36486,10 +38732,6 @@ components:
         runtime_readiness:
           anyOf:
           - $ref: '#/components/schemas/SmrLaunchPreflightRuntimeReadinessResponse'
-          - type: 'null'
-        resolved_actor_profiles:
-          anyOf:
-          - $ref: '#/components/schemas/SmrResolvedActorProfilesResponse'
           - type: 'null'
       type: object
       required:
@@ -37733,6 +39975,47 @@ components:
       required:
       - participant_kind
       title: SmrParticipantAuthorityEntry
+    SmrPatchHostedArtifactRequest:
+      properties:
+        title:
+          anyOf:
+          - type: string
+            maxLength: 500
+            minLength: 1
+          - type: 'null'
+          title: Title
+        metadata:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Metadata
+        theme:
+          anyOf:
+          - type: string
+            maxLength: 200
+          - type: 'null'
+          title: Theme
+        summary:
+          anyOf:
+          - type: string
+            maxLength: 4000
+          - type: 'null'
+          title: Summary
+        kind:
+          anyOf:
+          - type: string
+            maxLength: 40
+          - type: 'null'
+          title: Kind
+        visibility:
+          anyOf:
+          - type: string
+            maxLength: 20
+          - type: 'null'
+          title: Visibility
+      type: object
+      title: SmrPatchHostedArtifactRequest
     SmrPauseResourceResponse:
       properties:
         resource:
@@ -39670,9 +41953,9 @@ components:
           - $ref: '#/components/schemas/SmrAgentModel'
           - type: 'null'
           description: Override one shared agent model for this run. Shared top-level
-            values are 'baseten/zai-org/GLM-5.2', 'deepseek/deepseek-v4-flash', 'deepseek/deepseek-v4-flash-direct',
-            'deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-pro-direct', 'gpt-5.4-mini',
-            'gpt-5.5', 'x-ai/grok-4.3', 'x-ai/grok-build'. Use actor_model_overrides
+            values are 'arcee-ai/trinity-large-thinking', 'arcee-ai/trinity-large-thinking:free',
+            'deepseek/deepseek-v4-flash', 'deepseek/deepseek-v4-pro', 'gpt-5.4', 'gpt-5.4-mini',
+            'x-ai/grok-4.20-beta', 'x-ai/grok-4.3', 'x-ai/grok-build'. Use actor_model_overrides
             for actor-specific model selection.
         agent_harness:
           anyOf:
@@ -39705,12 +41988,9 @@ components:
           description: 'Override agent model params for this run (for example {''reasoning_effort'':
             ''medium''}).'
         actor_model_overrides:
-          anyOf:
-          - items:
-              $ref: '#/components/schemas/SmrActorModelSelectionRequest'
-            type: array
-          - additionalProperties: true
-            type: object
+          items:
+            $ref: '#/components/schemas/SmrActorModelSelectionRequest'
+          type: array
           title: Actor Model Overrides
           description: Deprecated compatibility input for actor-scoped model overrides
             keyed by actor_type and actor_subtype. Prefer roles for new integrations.
@@ -39732,19 +42012,11 @@ components:
           description: Run work mode override for this run.
         providers:
           items:
-            $ref: '#/components/schemas/ResourceProviderBinding'
+            $ref: '#/components/schemas/ProviderBinding'
           type: array
           title: Providers
           description: Run-scoped provider bindings. Supported public providers are
-            openrouter, xai, tinker, synth_ai, cursor, deepseek, baseten, and openai_chatgpt.
-        provider_policy:
-          anyOf:
-          - $ref: '#/components/schemas/ResourceProviderPolicy'
-          - type: 'null'
-          description: Declarative provider routing preferences. Use agent_inference
-            for agent actor traffic and experiment_inference for benchmark/eval model
-            traffic. Defaults require ZDR and US domicile/region for OpenAI, Baseten,
-            Gemini, and Grok-family providers.
+            openrouter, groq, xai, tinker, synth_ai, cursor, and deepseek.
         limit:
           anyOf:
           - $ref: '#/components/schemas/UsageLimit'
@@ -39752,7 +42024,7 @@ components:
           description: Optional run-scoped usage limit.
         required_capabilities:
           items:
-            $ref: '#/components/schemas/ResourceCapability'
+            $ref: '#/components/schemas/ActorResourceCapability'
           type: array
           title: Required Capabilities
           description: Internal proof-lane capability requirement. Defaults to inference.
@@ -39842,6 +42114,14 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SmrEnvironmentRefRequest'
           - type: 'null'
+        dev_environment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dev Environment Id
+          description: Optional live DevEnvironment binding. When provided, backend
+            validates the project-scoped dev environment and stamps launch_mode=dev_slot_execution
+            onto the run contract.
         primary_parent_ref:
           anyOf:
           - $ref: '#/components/schemas/SmrPrimaryParentRefRequest'
@@ -40149,6 +42429,41 @@ components:
       - funding_source
       - configured
       title: SmrProviderKeyStatusResponse
+    SmrPublishPublicArtifactRequest:
+      properties:
+        slug:
+          type: string
+          maxLength: 120
+          minLength: 1
+          title: Slug
+        kind:
+          type: string
+          title: Kind
+          default: result
+        theme:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Theme
+        summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Summary
+        factory_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Factory Id
+        effort_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+      type: object
+      required:
+      - slug
+      title: SmrPublishPublicArtifactRequest
     SmrQuestionRespondRequest:
       properties:
         response_text:
@@ -40337,6 +42652,15 @@ components:
       - label
       - href
       title: SmrReadinessCta
+    SmrRecordArtifactPageviewRequest:
+      properties:
+        session_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Id
+      type: object
+      title: SmrRecordArtifactPageviewRequest
     SmrRepoAddRequest:
       properties:
         repo:
@@ -40420,61 +42744,6 @@ components:
       - report_text
       - created_at
       title: SmrReportResponse
-    SmrResolvedActorProfilesResponse:
-      properties:
-        orchestrator:
-          $ref: '#/components/schemas/SmrResolvedProfileResponse'
-        workers:
-          items:
-            $ref: '#/components/schemas/SmrResolvedProfileResponse'
-          type: array
-          title: Workers
-        default_worker_profile_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Default Worker Profile Id
-      type: object
-      required:
-      - orchestrator
-      title: SmrResolvedActorProfilesResponse
-      description: "Platform-resolved actor execution for a hosted launch \u2014 no\
-        \ customer input.\n\nSurfaces what the platform chose (orchestrator + worker\
-        \ profiles) so history\nand dashboards never conflate requested vs platform-chosen\
-        \ models."
-    SmrResolvedProfileResponse:
-      properties:
-        role:
-          $ref: '#/components/schemas/SmrActorType'
-        profile_id:
-          type: string
-          title: Profile Id
-        model:
-          type: string
-          title: Model
-        agent_harness:
-          type: string
-          enum:
-          - codex
-          - cursor
-          - opencode_sdk
-          title: Agent Harness
-        agent_kind:
-          type: string
-          enum:
-          - codex
-          - cursor
-          - opencode_sdk
-          title: Agent Kind
-      type: object
-      required:
-      - role
-      - profile_id
-      - model
-      - agent_harness
-      - agent_kind
-      title: SmrResolvedProfileResponse
-      description: A single platform-resolved actor profile (read-only).
     SmrResourceKind:
       type: string
       enum:
@@ -41145,6 +43414,18 @@ components:
       - file_count
       - bytes_uploaded
       title: SmrResourceUploadResult
+    SmrReviewerSubtype:
+      type: string
+      enum:
+      - main
+      - task_completion
+      - run_completion
+      - safety
+      - objective
+      - seraph
+      - gardener
+      - artifact_reviewer
+      title: SmrReviewerSubtype
     SmrRoleBindingRequest:
       properties:
         model:
@@ -41177,13 +43458,6 @@ components:
           - type: 'null'
           title: Agent Kind
           description: Compatibility alias for agent_harness.
-        provider:
-          anyOf:
-          - additionalProperties: true
-            type: object
-          - type: 'null'
-          title: Provider
-          description: Optional role-level provider requirement.
       additionalProperties: false
       type: object
       required:
@@ -41195,6 +43469,14 @@ components:
           $ref: '#/components/schemas/SmrRoleBindingRequest'
         reviewer:
           $ref: '#/components/schemas/SmrRoleBindingRequest'
+        reviewer_subtypes:
+          additionalProperties:
+            $ref: '#/components/schemas/SmrRoleBindingRequest'
+          propertyNames:
+            $ref: '#/components/schemas/SmrReviewerSubtype'
+          type: object
+          title: Reviewer Subtypes
+          description: Optional subtype-specific reviewer bindings (e.g. artifact_reviewer).
         worker:
           $ref: '#/components/schemas/SmrWorkerRolePaletteRequest'
       additionalProperties: false
@@ -44378,7 +46660,7 @@ components:
           title: Providers
         capabilities:
           items:
-            $ref: '#/components/schemas/ResourceCapability'
+            $ref: '#/components/schemas/ActorResourceCapability'
           type: array
           title: Capabilities
         limits:
@@ -48254,6 +50536,27 @@ components:
           - type: 'null'
           title: Default Params
           description: Default worker model params.
+        agent_harness:
+          anyOf:
+          - type: string
+            enum:
+            - codex
+            - cursor
+            - opencode_sdk
+          - type: 'null'
+          title: Agent Harness
+          description: Optional default worker harness used when subtype override
+            is omitted.
+        agent_kind:
+          anyOf:
+          - type: string
+            enum:
+            - codex
+            - cursor
+            - opencode_sdk
+          - type: 'null'
+          title: Agent Kind
+          description: Compatibility alias for agent_harness.
         subtypes:
           additionalProperties:
             $ref: '#/components/schemas/SmrRoleBindingRequest'
@@ -48798,6 +51101,7 @@ components:
       enum:
       - engineer
       - researcher
+      - artifact_builder
       title: SmrWorkerSubtype
     SmrWorkerTaskClaimRequest:
       properties:
@@ -49050,6 +51354,253 @@ components:
       - last_30d_nominal_usd
       - last_30d_charged_usd
       title: SpendSummaryResponse
+    StackCrashReportItem:
+      properties:
+        event_id:
+          type: string
+          title: Event Id
+        client_event_id:
+          type: string
+          title: Client Event Id
+        observed_at:
+          type: string
+          title: Observed At
+        recorded_at:
+          type: string
+          format: date-time
+          title: Recorded At
+        crash_class:
+          type: string
+          title: Crash Class
+        surface:
+          type: string
+          title: Surface
+        message:
+          type: string
+          title: Message
+        version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
+        channel:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Channel
+        target:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target
+        source_ip_hash:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Ip Hash
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - event_id
+      - client_event_id
+      - observed_at
+      - recorded_at
+      - crash_class
+      - surface
+      - message
+      title: StackCrashReportItem
+    StackCrashReportListResponse:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+        total:
+          type: integer
+          title: Total
+        limit:
+          type: integer
+          title: Limit
+        offset:
+          type: integer
+          title: Offset
+        items:
+          items:
+            $ref: '#/components/schemas/StackCrashReportItem'
+          type: array
+          title: Items
+      type: object
+      required:
+      - ok
+      - total
+      - limit
+      - offset
+      - items
+      title: StackCrashReportListResponse
+    StackCrashReportRequest:
+      properties:
+        client_event_id:
+          type: string
+          maxLength: 160
+          minLength: 8
+          title: Client Event Id
+        observed_at:
+          type: string
+          maxLength: 64
+          minLength: 8
+          title: Observed At
+        crash_class:
+          type: string
+          maxLength: 80
+          minLength: 1
+          title: Crash Class
+        surface:
+          type: string
+          maxLength: 80
+          minLength: 1
+          title: Surface
+        message:
+          type: string
+          maxLength: 512
+          minLength: 1
+          title: Message
+        version:
+          anyOf:
+          - type: string
+            maxLength: 80
+          - type: 'null'
+          title: Version
+        channel:
+          anyOf:
+          - type: string
+            maxLength: 40
+          - type: 'null'
+          title: Channel
+        target:
+          anyOf:
+          - type: string
+            maxLength: 120
+          - type: 'null'
+          title: Target
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - client_event_id
+      - observed_at
+      - crash_class
+      - surface
+      - message
+      title: StackCrashReportRequest
+    StackCrashReportResponse:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+        event_id:
+          type: string
+          title: Event Id
+        deduplicated:
+          type: boolean
+          title: Deduplicated
+          default: false
+      type: object
+      required:
+      - ok
+      - event_id
+      title: StackCrashReportResponse
+    StackCrashReportSummaryResponse:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+        window_days:
+          type: integer
+          title: Window Days
+        total:
+          type: integer
+          title: Total
+        by_crash_class:
+          additionalProperties:
+            type: integer
+          type: object
+          title: By Crash Class
+        by_surface:
+          additionalProperties:
+            type: integer
+          type: object
+          title: By Surface
+        by_version:
+          additionalProperties:
+            type: integer
+          type: object
+          title: By Version
+        recent:
+          items:
+            $ref: '#/components/schemas/StackCrashReportItem'
+          type: array
+          title: Recent
+      type: object
+      required:
+      - ok
+      - window_days
+      - total
+      - by_crash_class
+      - by_surface
+      - by_version
+      - recent
+      title: StackCrashReportSummaryResponse
+    StackUsageEventsRequest:
+      properties:
+        schema_version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Schema Version
+        product:
+          type: string
+          maxLength: 40
+          title: Product
+          default: stack
+        events:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Events
+      type: object
+      title: StackUsageEventsRequest
+    StackUsageEventsResponse:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+        accepted:
+          type: integer
+          title: Accepted
+        recorded:
+          type: integer
+          title: Recorded
+        duplicates:
+          type: integer
+          title: Duplicates
+        event_ids:
+          items:
+            type: string
+          type: array
+          title: Event Ids
+      type: object
+      required:
+      - ok
+      - accepted
+      - recorded
+      - duplicates
+      - event_ids
+      title: StackUsageEventsResponse
     StartingDataUploadUrlsRequest:
       properties:
         dataset_ref:
@@ -49451,6 +52002,27 @@ components:
             maxLength: 128
           - type: 'null'
           title: Runbook Preset
+        host_kind:
+          anyOf:
+          - $ref: '#/components/schemas/SmrHostKind'
+          - type: 'null'
+        worker_pool_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Worker Pool Id
+        local_execution:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Local Execution
+        execution_profile:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Execution Profile
         metadata:
           additionalProperties: true
           type: object
@@ -50586,7 +53158,7 @@ components:
         entitlements:
           $ref: '#/components/schemas/BillingEntitlementSnapshot'
         usage_summary:
-          $ref: '#/components/schemas/UsageSummaryResponse'
+          $ref: '#/components/schemas/app__api__v1__routes_usage_overview__UsageSummaryResponse'
         spend_summary:
           $ref: '#/components/schemas/SpendSummaryResponse'
         sources:
@@ -50799,86 +53371,32 @@ components:
             used: 2400
     UsageSummaryResponse:
       properties:
-        total_nominal_usd:
+        org_id:
+          type: string
+          title: Org Id
+        date_range:
+          type: string
+          title: Date Range
+        total_cost_cents:
+          type: integer
+          title: Total Cost Cents
+        total_cost_dollars:
           type: number
-          title: Total Nominal Usd
-        total_cost_usd:
+          title: Total Cost Dollars
+        gpu_events_count:
+          type: integer
+          title: Gpu Events Count
+        total_gpu_seconds:
           type: number
-          title: Total Cost Usd
-        total_charged_usd:
-          type: number
-          title: Total Charged Usd
-        total_internal_cost_usd:
-          type: number
-          title: Total Internal Cost Usd
-        by_type:
-          items:
-            $ref: '#/components/schemas/UsageByTypeResponse'
-          type: array
-          title: By Type
-        by_job:
-          items:
-            additionalProperties:
-              type: string
-            type: object
-          type: array
-          title: By Job
-        by_project:
-          items:
-            $ref: '#/components/schemas/UsageByProjectResponse'
-          type: array
-          title: By Project
-        by_factory:
-          items:
-            $ref: '#/components/schemas/UsageByFactoryResponse'
-          type: array
-          title: By Factory
-        by_source_type:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Source Type
-        by_source_subtype:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Source Subtype
-        by_source_provider:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Source Provider
-        by_funding_lane:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Funding Lane
-        by_execution_path:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Execution Path
-        by_actor:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Actor
-        by_billing_route:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Billing Route
-        by_pricing_policy:
-          additionalProperties:
-            $ref: '#/components/schemas/UsageBreakdownValueResponse'
-          type: object
-          title: By Pricing Policy
+          title: Total Gpu Seconds
       type: object
       required:
-      - total_nominal_usd
-      - total_cost_usd
-      - total_charged_usd
-      - total_internal_cost_usd
+      - org_id
+      - date_range
+      - total_cost_cents
+      - total_cost_dollars
+      - gpu_events_count
+      - total_gpu_seconds
       title: UsageSummaryResponse
     UsageType:
       type: string
@@ -51370,35 +53888,6 @@ components:
           title: Fingerprint
       type: object
       title: _SubmitterIn
-    app__api__v1__admin__UsageSummaryResponse:
-      properties:
-        org_id:
-          type: string
-          title: Org Id
-        date_range:
-          type: string
-          title: Date Range
-        total_cost_cents:
-          type: integer
-          title: Total Cost Cents
-        total_cost_dollars:
-          type: number
-          title: Total Cost Dollars
-        gpu_events_count:
-          type: integer
-          title: Gpu Events Count
-        total_gpu_seconds:
-          type: number
-          title: Total Gpu Seconds
-      type: object
-      required:
-      - org_id
-      - date_range
-      - total_cost_cents
-      - total_cost_dollars
-      - gpu_events_count
-      - total_gpu_seconds
-      title: UsageSummaryResponse
     app__api__v1__managed_research__limits__LimitResponse:
       properties:
         scope_kind:
@@ -51494,6 +53983,89 @@ components:
       - last_30_days
       title: UsageSummaryResponse
       description: Response model for usage summary.
+    app__api__v1__routes_usage_overview__UsageSummaryResponse:
+      properties:
+        total_nominal_usd:
+          type: number
+          title: Total Nominal Usd
+        total_cost_usd:
+          type: number
+          title: Total Cost Usd
+        total_charged_usd:
+          type: number
+          title: Total Charged Usd
+        total_internal_cost_usd:
+          type: number
+          title: Total Internal Cost Usd
+        by_type:
+          items:
+            $ref: '#/components/schemas/UsageByTypeResponse'
+          type: array
+          title: By Type
+        by_job:
+          items:
+            additionalProperties:
+              type: string
+            type: object
+          type: array
+          title: By Job
+        by_project:
+          items:
+            $ref: '#/components/schemas/UsageByProjectResponse'
+          type: array
+          title: By Project
+        by_factory:
+          items:
+            $ref: '#/components/schemas/UsageByFactoryResponse'
+          type: array
+          title: By Factory
+        by_source_type:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Source Type
+        by_source_subtype:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Source Subtype
+        by_source_provider:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Source Provider
+        by_funding_lane:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Funding Lane
+        by_execution_path:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Execution Path
+        by_actor:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Actor
+        by_billing_route:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Billing Route
+        by_pricing_policy:
+          additionalProperties:
+            $ref: '#/components/schemas/UsageBreakdownValueResponse'
+          type: object
+          title: By Pricing Policy
+      type: object
+      required:
+      - total_nominal_usd
+      - total_cost_usd
+      - total_charged_usd
+      - total_internal_cost_usd
+      title: UsageSummaryResponse
   securitySchemes:
     HTTPBearer:
       type: http

--- a/synth_ai/managed_research/sdk/dev_environments.py
+++ b/synth_ai/managed_research/sdk/dev_environments.py
@@ -168,8 +168,8 @@ class DevEnvironmentsAPI(_ClientNamespace):
         *,
         environment: DevEnvironment,
         run_binding_summary: Mapping[str, object],
-    ) -> list[dict[str, object]]:
-        proofs: list[dict[str, object]] = []
+    ) -> List[dict[str, object]]:
+        proofs: List[dict[str, object]] = []
         for run_id in run_binding_summary.get("bound_run_ids") or ():
             run_id_text = str(run_id or "").strip()
             if not run_id_text:
@@ -223,16 +223,14 @@ class DevEnvironmentsAPI(_ClientNamespace):
         environment: DevEnvironment,
         usage: DevEnvironmentUsage,
         receipts: DevEnvironmentCollection,
-        run_proofs: list[dict[str, object]],
+        run_proofs: List[dict[str, object]],
     ) -> dict[str, object]:
         receipt_summary = receipts.summary
         hydrated_work_product_count = sum(
-            cls._int_summary_value(proof.get("work_product_count"))
-            for proof in run_proofs
+            cls._int_summary_value(proof.get("work_product_count")) for proof in run_proofs
         )
         hydrated_ready_work_product_count = sum(
-            cls._int_summary_value(proof.get("ready_work_product_count"))
-            for proof in run_proofs
+            cls._int_summary_value(proof.get("ready_work_product_count")) for proof in run_proofs
         )
         hydrated_trace_count = sum(
             cls._int_summary_value(proof.get("trace_count")) for proof in run_proofs
@@ -251,9 +249,8 @@ class DevEnvironmentsAPI(_ClientNamespace):
         )
         usage_summary = usage.summary or receipts.usage.get("summary")
         has_usage_snapshot = bool(usage_summary)
-        has_cost_snapshot = bool(environment.cost_summary) or bool(
-            receipts.environment.get("cost_summary")
-        )
+        receipt_cost_summary = receipts.environment.get("cost_summary")
+        has_cost_snapshot = bool(environment.cost_summary) or bool(receipt_cost_summary)
         checks = {
             "environment_id_bound": run_binding_summary.get("has_bound_run") is True,
             "dev_slot_execution_bound": (
@@ -274,7 +271,9 @@ class DevEnvironmentsAPI(_ClientNamespace):
             "cost_summary": (
                 dict(environment.cost_summary)
                 if environment.cost_summary
-                else dict(receipts.environment.get("cost_summary", {}))
+                else dict(receipt_cost_summary)
+                if isinstance(receipt_cost_summary, Mapping)
+                else {}
             ),
             "usage_summary": dict(usage_summary) if isinstance(usage_summary, Mapping) else {},
             "latest_run_binding": run_binding_summary.get("latest_run_binding"),
@@ -291,7 +290,7 @@ class DevEnvironmentsAPI(_ClientNamespace):
         runs: DevEnvironmentCollection,
         usage: DevEnvironmentUsage,
         receipts: DevEnvironmentCollection,
-        run_proofs: list[dict[str, object]],
+        run_proofs: List[dict[str, object]],
         billing_preflight: SmrBillingPreflight | None,
         billing_drawdown: SmrBillingDrawdown | None,
     ) -> dict[str, object]:
@@ -610,8 +609,8 @@ class DevEnvironmentsAPI(_ClientNamespace):
         result: str = "succeeded",
         lifecycle_state: str | None = None,
         service_summary: Mapping[str, Any] | None = None,
-        log_entries: list[Mapping[str, Any]] | None = None,
-        receipt_refs: list[Mapping[str, Any]] | None = None,
+        log_entries: List[Mapping[str, Any]] | None = None,
+        receipt_refs: List[Mapping[str, Any]] | None = None,
         metadata: Mapping[str, Any] | None = None,
         error: Mapping[str, Any] | None = None,
     ) -> DevEnvironment:
@@ -760,7 +759,7 @@ class DevEnvironmentsAPI(_ClientNamespace):
         self,
         dev_environment_id: str,
         *,
-        lifecycle_states: tuple[str, ...] | list[str] | None = None,
+        lifecycle_states: tuple[str, ...] | List[str] | None = None,
         timeout: float | None = 1800.0,
         poll_interval: float = 10.0,
         require_readiness: bool = True,
@@ -803,7 +802,7 @@ class DevEnvironmentsAPI(_ClientNamespace):
     @classmethod
     def _normalized_lifecycle_targets(
         cls,
-        lifecycle_states: tuple[str, ...] | list[str] | None,
+        lifecycle_states: tuple[str, ...] | List[str] | None,
     ) -> tuple[str, ...]:
         raw_states = lifecycle_states or cls.DEFAULT_READY_LIFECYCLE_STATES
         states = tuple(state for state in (str(item or "").strip() for item in raw_states) if state)

--- a/synth_ai/research/hosted_artifacts.py
+++ b/synth_ai/research/hosted_artifacts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, List
 
 from synth_ai.managed_research.sdk.client import ManagedResearchClient
 
@@ -48,7 +48,7 @@ class ResearchHostedArtifactsAPI:
         *,
         project_id: str | None = None,
         limit: int = 100,
-    ) -> list[dict[str, Any]]:
+    ) -> List[dict[str, Any]]:
         """List hosted artifacts for the org or one project.
 
         Args:
@@ -60,13 +60,9 @@ class ResearchHostedArtifactsAPI:
             and ``slug`` when promoted.
         """
         if project_id:
-            payload = self._session.list_project_hosted_artifacts(
-                project_id, limit=limit
-            )
+            payload = self._session.list_project_hosted_artifacts(project_id, limit=limit)
         else:
-            payload = self._session.list_hosted_artifacts(
-                project_id=project_id, limit=limit
-            )
+            payload = self._session.list_hosted_artifacts(project_id=project_id, limit=limit)
         return _artifact_items(payload)
 
     def get(self, hosted_artifact_id: str) -> dict[str, Any]:
@@ -192,7 +188,7 @@ class ResearchHostedArtifactsAPI:
         """
         return self._session.delete_hosted_artifact(hosted_artifact_id)
 
-    def list_public(self) -> list[dict[str, Any]]:
+    def list_public(self) -> List[dict[str, Any]]:
         """List public Open Research artifacts (unauthenticated index JSON)."""
         payload = self._session.list_public_hosted_artifacts()
         return _artifact_items(payload)

--- a/synth_ai/sdk/pools.py
+++ b/synth_ai/sdk/pools.py
@@ -50,6 +50,7 @@ def validate_pool_rollout_request(request: dict[str, Any], *, context: str) -> N
 
 class PoolTarget(str, Enum):
     """Deployment target substrate for a pool."""
+
     HARBOR = "harbor"
     OPENENV = "openenv"
     HORIZONS = "horizons"
@@ -186,6 +187,7 @@ class _PoolMetricsClient:
 
 class ContainerPoolsClient(SynthBaseClient):
     """Manage container pools, tasks, rollouts, and metrics."""
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
Summary
- refresh vendored Managed Research OpenAPI snapshot from backend staging contract
- refresh public model catalog snapshot generated with the same backend contract
- includes the /smr/dev-environments* and /smr/billing/dev-environments* routes now present in backend smr_openapi.yaml

Validation
- From backend worktree: uv run python scripts/validate_smr_openapi.py --repo backend
- From backend worktree: uv run python scripts/validate_smr_openapi.py --repo synth-ai