### PR TITLE
fix(smr): require explicit control client backend

### DIFF
--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -6085,8 +6085,8 @@ class SmrControlClient(SmrControlClientMixin, ManagedResearchClient):
     """Compatibility alias that retains the legacy synth-ai bridge surface.
 
     `ManagedResearchClient` is the canonical public name. `SmrControlClient`
-    remains as a one-release alias and preserves the older default-backend +
-    synth-ai bridge behavior for migration safety.
+    remains as a one-release alias but requires callers to pass the selected
+    backend explicitly so default construction cannot silently target prod.
     """
 
     def __init__(
@@ -6099,9 +6099,16 @@ class SmrControlClient(SmrControlClientMixin, ManagedResearchClient):
         openai_project: str | None = None,
         openai_request_id: str | None = None,
     ) -> None:
+        explicit_backend_base = str(backend_base or "").strip()
+        if not explicit_backend_base:
+            raise ValueError(
+                "SmrControlClient requires an explicit backend_base. "
+                "Pass backend_base from the selected environment instead of "
+                "relying on SYNTH_BACKEND_URL or the prod SDK default."
+            )
         super().__init__(
             api_key=api_key,
-            backend_base=backend_base,
+            backend_base=explicit_backend_base,
             timeout_seconds=timeout_seconds,
         )
         self._initialize_openai_bridge(

--- a/synth_ai/sdk/pools.py
+++ b/synth_ai/sdk/pools.py
@@ -50,6 +50,7 @@ def validate_pool_rollout_request(request: dict[str, Any], *, context: str) -> N
 
 class PoolTarget(str, Enum):
     """Deployment target substrate for a pool."""
+
     HARBOR = "harbor"
     OPENENV = "openenv"
     HORIZONS = "horizons"
@@ -186,6 +187,7 @@ class _PoolMetricsClient:
 
 class ContainerPoolsClient(SynthBaseClient):
     """Manage container pools, tasks, rollouts, and metrics."""
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
## Summary
- Require legacy SmrControlClient callers to pass backend_base explicitly.
- Preserve ManagedResearchClient as the canonical client while preventing default construction from silently targeting prod.

## Validation
- uv run python -m py_compile synth_ai/managed_research/sdk/client.py
- git diff --check
- uv run python -c "from synth_ai.managed_research.sdk.client import SmrControlClient; ..." -> smr_control_explicit_base_ok

## Notes
- No tests added per workspace instruction; this is a narrow SDK guardrail from the SMR hardening day-one list.