### PR TITLE
Restore pools SDK Ruff formatting baseline

### DIFF
--- a/synth_ai/sdk/pools.py
+++ b/synth_ai/sdk/pools.py
@@ -50,6 +50,7 @@ def validate_pool_rollout_request(request: dict[str, Any], *, context: str) -> N
 
 class PoolTarget(str, Enum):
     """Deployment target substrate for a pool."""
+
     HARBOR = "harbor"
     OPENENV = "openenv"
     HORIZONS = "horizons"
@@ -186,6 +187,7 @@ class _PoolMetricsClient:
 
 class ContainerPoolsClient(SynthBaseClient):
     """Manage container pools, tasks, rollouts, and metrics."""
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
## Summary

Formats `synth_ai/sdk/pools.py`, the pre-existing source reported by the main CI lint gate.

This is formatter-only baseline repair and contains no economics or billing changes.

## Root cause

Current `main` contains Ruff formatting drift, so unrelated release PRs fail `ruff format --check`.

## Validation

- `UV_CACHE_DIR=/tmp/codex-baseline-uv uv run ruff format --check` (185 files formatted)
- `git diff --check`