### PR TITLE
release: publish economics SDK as 0.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.13.1-orange synth-ai==0.13.1 -->
+<!-- CI release pins: PyPI-0.14.1-orange synth-ai==0.14.1 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.13.1"
+version = "0.14.1"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.13.1"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Corrects release ordering after 0.13.1 published below the existing public 0.14.0. No runtime code changes: this bumps the already-merged economics SDK to 0.14.1 so default installs expose ManagedResearchClient.billing.\n\nValidation: uv lock --check; uv build; public 0.14.0 fresh-install check confirmed the missing billing property.