### PR TITLE
Release backend model parity in synth-ai 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `synth-ai` package are documented here.
 
+## 0.14.2 — 2026-07-10
+
+### Added
+
+- Typed `SmrAgentModel` coverage for every model in the backend-owned supported-model
+  catalog, including `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and
+  `cursor/grok-4.5`.
+
+### Changed
+
+- The vendored Managed Research OpenAPI model enum now matches the backend catalog.
+- Existing model values, including `gpt-5.4` and internal compatibility values, remain
+  importable so the daily release does not break existing typed callers.
+
 ## 0.13.1 — 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.14.1-orange synth-ai==0.14.1 -->
+<!-- CI release pins: PyPI-0.14.2-orange synth-ai==0.14.2 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.14.1"
+version = "0.14.2"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/managed_research/models/smr_agent_models.py
+++ b/synth_ai/managed_research/models/smr_agent_models.py
@@ -1,6 +1,6 @@
-"""Generated public Managed Research agent model enum.
+"""Generated Managed Research agent model enum.
 
-Source of truth: backend/config/smr_public_models.json
+Source of truth: backend/packages/smr/config/supported_models_catalog.py
 """
 
 from __future__ import annotations
@@ -9,14 +9,31 @@ from enum import StrEnum
 
 
 class SmrAgentModel(StrEnum):
+    GPT_5_CODEX = "gpt-5-codex"
     GPT_5_3_CODEX = "gpt-5.3-codex"
     GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark"
     GPT_5_5 = "gpt-5.5"
     GPT_5_4_MINI = "gpt-5.4-mini"
+    GPT_5_6_SOL = "gpt-5.6-sol"
+    GPT_5_6_TERRA = "gpt-5.6-terra"
+    GPT_5_6_LUNA = "gpt-5.6-luna"
+    NEMOTRON_SUPER = "nemotron-super"
+    DEEPSEEK_DEEPSEEK_V4_FLASH = "deepseek/deepseek-v4-flash"
+    DEEPSEEK_DEEPSEEK_V4_PRO = "deepseek/deepseek-v4-pro"
+    CURSOR_COMPOSER_2_5 = "cursor/composer-2.5"
+    CURSOR_GPT_5 = "cursor/gpt-5"
+    CURSOR_GROK_4_5 = "cursor/grok-4.5"
+    CURSOR_SONNET_4 = "cursor/sonnet-4"
     X_AI_GROK_4_3 = "x-ai/grok-4.3"
     X_AI_GROK_BUILD = "x-ai/grok-build"
     MOONSHOTAI_KIMI_K2_6 = "moonshotai/kimi-k2.6"
     BASETEN_ZAI_ORG_GLM_5_2 = "baseten/zai-org/GLM-5.2"
+    MODAL_ZAI_ORG_GLM_5_2_FP8 = "modal/zai-org/GLM-5.2-FP8"
+    DEEPSEEK_DEEPSEEK_V4_FLASH_DIRECT = "deepseek/deepseek-v4-flash-direct"
+    DEEPSEEK_DEEPSEEK_V4_PRO_DIRECT = "deepseek/deepseek-v4-pro-direct"
+    DEEPSEEK_DEEPSEEK_CHAT = "deepseek/deepseek-chat"
+    DEEPSEEK_DEEPSEEK_REASONER = "deepseek/deepseek-reasoner"
+    GPT_5_4 = "gpt-5.4"
 
 
 SMR_AGENT_MODEL_VALUES: tuple[str, ...] = tuple(model.value for model in SmrAgentModel)

--- a/synth_ai/managed_research/schema_sync.py
+++ b/synth_ai/managed_research/schema_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import shutil
@@ -46,6 +47,13 @@ def _enum_member_name(model_id: str) -> str:
 def _default_backend_manifest_path() -> Path:
     workspace_root = Path(__file__).resolve().parents[3]
     return workspace_root / "backend" / "config" / "smr_supported_models.json"
+
+
+def _default_backend_supported_models_path() -> Path:
+    workspace_root = Path(__file__).resolve().parents[3]
+    return (
+        workspace_root / "backend" / "packages" / "smr" / "config" / "supported_models_catalog.py"
+    )
 
 
 def _default_backend_public_models_path() -> Path:
@@ -161,6 +169,8 @@ _STATIC_ENUM_SPECS: tuple[tuple[str, str, str, tuple[str, ...]], ...] = (
     ),
 )
 
+_SMR_AGENT_MODEL_COMPATIBILITY_VALUES: tuple[str, ...] = ("gpt-5.4",)
+
 
 def _render_static_enum_module(
     *,
@@ -245,31 +255,47 @@ def sync_smr_agent_models(
     source_manifest: Path | None = None,
     destination_file: Path | None = None,
 ) -> Path:
-    """Generate the public Managed Research model enum from the backend public-model export."""
+    """Generate the Managed Research model enum from the backend-supported catalog."""
 
-    source = source_manifest or _default_backend_public_models_path()
+    source = source_manifest or _default_backend_supported_models_path()
     destination = destination_file or (
         Path(__file__).resolve().parent / "models" / "smr_agent_models.py"
     )
-    raw = json.loads(source.read_text(encoding="utf-8"))
-    models = raw.get("models")
-    if not isinstance(models, list) or not models:
-        raise ValueError(
-            "Managed Research public model manifest must contain a non-empty models list"
-        )
+    if source.suffix == ".py":
+        module = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        models = None
+        for node in module.body:
+            if isinstance(node, ast.AnnAssign):
+                if (
+                    isinstance(node.target, ast.Name)
+                    and node.target.id == "SUPPORTED_MODEL_ENTRIES"
+                    and node.value is not None
+                ):
+                    models = ast.literal_eval(node.value)
+                    break
+            elif isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id == "SUPPORTED_MODEL_ENTRIES"
+                for target in node.targets
+            ):
+                models = ast.literal_eval(node.value)
+                break
+    else:
+        raw = json.loads(source.read_text(encoding="utf-8"))
+        models = raw.get("models")
+    if not isinstance(models, (list, tuple)) or not models:
+        raise ValueError("Managed Research supported-model source must contain non-empty models")
 
-    model_ids = [
-        str(item.get("id") or "").strip()
-        for item in models
-        if isinstance(item, dict) and bool(item.get("public", True))
-    ]
+    model_ids = [str(item.get("id") or "").strip() for item in models if isinstance(item, dict)]
     if not model_ids or any(not model_id for model_id in model_ids):
-        raise ValueError("Managed Research public model manifest entries require non-empty ids")
+        raise ValueError("Managed Research supported-model entries require non-empty ids")
+    model_ids.extend(
+        model_id for model_id in _SMR_AGENT_MODEL_COMPATIBILITY_VALUES if model_id not in model_ids
+    )
 
     lines = [
-        '"""Generated public Managed Research agent model enum.',
+        '"""Generated Managed Research agent model enum.',
         "",
-        "Source of truth: backend/config/smr_public_models.json",
+        "Source of truth: backend/packages/smr/config/supported_models_catalog.py",
         '"""',
         "",
         "from __future__ import annotations",

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -34820,11 +34820,15 @@ components:
       - gpt-5.5
       - gpt-5.4
       - gpt-5.4-mini
+      - gpt-5.6-sol
+      - gpt-5.6-terra
+      - gpt-5.6-luna
       - nemotron-super
       - deepseek/deepseek-v4-flash
       - deepseek/deepseek-v4-pro
       - cursor/composer-2.5
       - cursor/gpt-5
+      - cursor/grok-4.5
       - cursor/sonnet-4
       - x-ai/grok-4.3
       - x-ai/grok-build

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Daily synth-ai release adding typed coverage for the backend-owned supported model catalog, including gpt-5.6-luna. Preserves gpt-5.4 compatibility.\n\nValidation: Ruff format/check, ty, generator parity (24 backend + compatibility = 25 SDK/OpenAPI), docs-check, build, Twine, fresh Python 3.11 wheel imports, typed denial errors, 444 unique MCP tools, and uv-tool install.