### PR TITLE
Allow manual recovery for PyPI publishing

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,6 +1,7 @@
 name: Auto-publish to PyPI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
The synth-ai 0.14.2 merge did not enqueue the main-only trusted-publisher workflow. Add the minimal manual dispatch trigger so authorized operators can recover without raw PyPI credentials.