### PR TITLE
fix(ci): remediate dev Docs/Lint failures from #240

### DIFF
--- a/synth_ai/managed_research/models/factories.py
+++ b/synth_ai/managed_research/models/factories.py
@@ -1269,9 +1269,7 @@ class FactoryWorkProductSummary:
             status=_require_string(mapping, "status", label="work_product.status"),
             readiness=_require_string(mapping, "readiness", label="work_product.readiness"),
             artifact_id=_optional_string(mapping, "artifact_id"),
-            metadata=_optional_object_dict(
-                mapping.get("metadata"), label="work_product.metadata"
-            ),
+            metadata=_optional_object_dict(mapping.get("metadata"), label="work_product.metadata"),
             created_at=_optional_datetime(mapping, "created_at"),
             updated_at=_optional_datetime(mapping, "updated_at"),
             raw=dict(mapping),

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -1834,6 +1834,7 @@ class ManagedResearchClient:
             ),
             label="compare_experiments",
         )
+
     def create_factory_idea(
         self,
         factory_id: str,

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -129,6 +129,16 @@ class ResearchFactoriesTagSessionsAPI:
         effort_id: str | None = None,
         limit: int = 50,
     ) -> tuple[TagSession, ...]:
+        """List Tag sessions, optionally filtered by factory or effort.
+
+        Args:
+            factory_id: Only sessions bound to this factory.
+            effort_id: Only sessions bound to this effort.
+            limit: Maximum sessions returned (newest first).
+
+        Returns:
+            Tuple of ``TagSession`` records.
+        """
         return self._session.tag.list_sessions(
             factory_id=factory_id,
             effort_id=effort_id,
@@ -136,6 +146,14 @@ class ResearchFactoriesTagSessionsAPI:
         )
 
     def watch(self, session_id: str) -> TagSessionWatch:
+        """Open a watch handle that polls the session until it is terminal.
+
+        Args:
+            session_id: Tag session to observe.
+
+        Returns:
+            ``TagSessionWatch`` iterator of session state snapshots.
+        """
         return self._session.tag.watch_session(session_id)
 
     def control(
@@ -143,6 +161,15 @@ class ResearchFactoriesTagSessionsAPI:
         session_id: str,
         action: TagSessionControlAction | str,
     ) -> TagSession:
+        """Apply a control action (for example pause, resume, cancel) to a session.
+
+        Args:
+            session_id: Tag session to control.
+            action: ``TagSessionControlAction`` or its string value.
+
+        Returns:
+            Updated ``TagSession`` after the action is applied.
+        """
         return self._session.tag.control_session(session_id, action)
 
 


### PR DESCRIPTION
Remediates the two CI failures waived at the #240 merge:

- Lint: ruff format on managed_research/models/factories.py + managed_research/sdk/client.py
- Docs: docstrings for ResearchFactoriesTagSessionsAPI.{list,watch,control} (docstring gate)

Both gates verified locally: docstring gate passed (17 manifest modules), 197 files already formatted. Unblocks the dev → nightly promote (publication step 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)