### PR TITLE
Seed Effort launches from stored objective

### DIFF
--- a/synth_ai/managed_research/sdk/factories.py
+++ b/synth_ai/managed_research/sdk/factories.py
@@ -914,26 +914,19 @@ class EffortsAPI(_ClientNamespace):
         run_kind: str = "research",
         **kwargs: Any,
     ):
-        from synth_ai.managed_research.models.run_state import ManagedResearchRun
-        from synth_ai.managed_research.sdk.runs import RunHandle
-
         effort = self.get(effort_id)
-        if objective is not None:
-            return self._client.runs.start(
-                objective,
-                project_id=effort.project_id,
-                effort_id=effort.effort_id,
-                run_kind=run_kind,
-                **kwargs,
-            )
-        wire = self._client.trigger_run(
-            effort.project_id,
+        objective_text = (
+            str(effort.hypothesis_or_topic or effort.name or "").strip()
+            if objective is None
+            else str(objective).strip()
+        )
+        return self._client.runs.start(
+            objective_text,
+            project_id=effort.project_id,
             effort_id=effort.effort_id,
             run_kind=run_kind,
             **kwargs,
         )
-        run = ManagedResearchRun.from_wire(wire)
-        return RunHandle(self._client, run.project_id, run.run_id)
 
     def launch_maintenance(
         self,


### PR DESCRIPTION
## What changed

`EffortsAPI.launch` now defaults a missing explicit objective to the stored Effort hypothesis or name and always uses the typed run-start path.

## Why

The previous raw trigger branch could send only `effort_id`, allocating a backend run without `launch_context.objective_text`.

## Validation

- Python compilation
- Fake-client assertion proving the stored objective, effort id, run kind, and pool arguments reach `runs.start`
- `git diff --check`

CI, Ruff, and ty were intentionally skipped per release-coordinator direction.
