### PR TITLE
chore: re-vendor SMR OpenAPI snapshot from fresh backend export

### DIFF
--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -266,7 +266,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/app__api__v1__routes_balance__UsageSummaryResponse'
+                $ref: '#/components/schemas/UsageSummaryResponse'
   /api/v1/balance/autumn-current:
     get:
       tags:
@@ -3135,379 +3135,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/runtime/ensure:
-    post:
-      summary: Ensure Runtime Session
-      operationId: ensure_runtime_session_smr_runtime_control_runtime_ensure_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EnsureRuntimeSessionRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Ensure Runtime Session Smr Runtime Control Runtime
-                  Ensure Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/runtime/shutdown:
-    post:
-      summary: Shutdown Runtime Session
-      operationId: shutdown_runtime_session_smr_runtime_control_runtime_shutdown_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ShutdownRuntimeSessionRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Shutdown Runtime Session Smr Runtime Control Runtime
-                  Shutdown Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/runtime/enqueue_initial_messages:
-    post:
-      summary: Enqueue Initial Runtime Messages
-      operationId: enqueue_initial_runtime_messages_smr_runtime_control_runtime_enqueue_initial_messages_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EnqueueInitialRuntimeMessagesRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Enqueue Initial Runtime Messages Smr Runtime Control
-                  Runtime Enqueue Initial Messages Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/runtime/enqueue_message:
-    post:
-      summary: Enqueue Runtime Message
-      operationId: enqueue_runtime_message_smr_runtime_control_runtime_enqueue_message_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EnqueueRuntimeMessageRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Enqueue Runtime Message Smr Runtime Control Runtime
-                  Enqueue Message Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/runtime/publish_wakeup:
-    post:
-      summary: Publish Runtime Wakeup
-      operationId: publish_runtime_wakeup_smr_runtime_control_runtime_publish_wakeup_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PublishRuntimeWakeupRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Publish Runtime Wakeup Smr Runtime Control Runtime
-                  Publish Wakeup Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/mcp/call_tool:
-    post:
-      summary: Call Runtime Mcp Tool
-      operationId: call_runtime_mcp_tool_smr_runtime_control_mcp_call_tool_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RuntimeMcpToolCallRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Call Runtime Mcp Tool Smr Runtime Control Mcp Call
-                  Tool Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/local/reset_live_sessions:
-    post:
-      summary: Reset Process Local Live Sessions
-      operationId: reset_process_local_live_sessions_smr_runtime_control_local_reset_live_sessions_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-              title: Payload
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Reset Process Local Live Sessions Smr Runtime Control
-                  Local Reset Live Sessions Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/lifecycle/signal_projection:
-    post:
-      summary: Apply Run Workflow Signal Projection
-      operationId: apply_run_workflow_signal_projection_smr_runtime_control_lifecycle_signal_projection_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-              title: Payload
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Apply Run Workflow Signal Projection Smr Runtime Control
-                  Lifecycle Signal Projection Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/state_machine/advance:
-    post:
-      summary: Advance State Machine Turn
-      operationId: advance_state_machine_turn_smr_runtime_control_state_machine_advance_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-              title: Payload
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Advance State Machine Turn Smr Runtime Control State
-                  Machine Advance Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/superstep/execute:
-    post:
-      summary: Advance State Machine Turn
-      operationId: advance_state_machine_turn_smr_runtime_control_superstep_execute_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-              title: Payload
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Advance State Machine Turn Smr Runtime Control Superstep
-                  Execute Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /smr/runtime/control/codex_turn/interrupt:
-    post:
-      summary: Interrupt Managed Codex Turn
-      operationId: interrupt_managed_codex_turn_smr_runtime_control_codex_turn_interrupt_post
-      parameters:
-      - name: X-SMR-Worker-Key
-        in: header
-        required: true
-        schema:
-          type: string
-          title: X-Smr-Worker-Key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-              title: Payload
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Interrupt Managed Codex Turn Smr Runtime Control Codex
-                  Turn Interrupt Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /smr/projects:runnable:
     post:
       tags:
@@ -5203,41 +4830,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /smr/projects/{project_id}/experiments/{experiment_id}/inspect:
-    get:
-      tags:
-      - smr
-      - experiments
-      summary: Inspect Project Experiment
-      description: Return the canonical bundle with its human-oriented inspection
-        projection.
-      operationId: inspect_project_experiment_smr_projects__project_id__experiments__experiment_id__inspect_get
-      parameters:
-      - name: project_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Project Id
-      - name: experiment_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Experiment Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SmrExperimentBundleResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /smr/projects/{project_id}/experiment-bundles:
     get:
       tags:
@@ -6445,6 +6037,203 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /smr/factories/{factory_id}/candidates:
+    get:
+      tags:
+      - smr
+      - factories
+      summary: List Factory Candidates
+      operationId: list_factory_candidates_smr_factories__factory_id__candidates_get
+      parameters:
+      - name: factory_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Factory Id
+      - name: grading_status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Grading Status
+      - name: effort_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 200
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SmrFactoryCandidateResponse'
+                title: Response List Factory Candidates Smr Factories  Factory Id  Candidates
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/factories/{factory_id}/candidates/{candidate_id}/grading:
+    post:
+      tags:
+      - smr
+      - factories
+      summary: Record Factory Candidate Grading
+      operationId: record_factory_candidate_grading_smr_factories__factory_id__candidates__candidate_id__grading_post
+      parameters:
+      - name: factory_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Factory Id
+      - name: candidate_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Candidate Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrFactoryCandidateGradingRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmrFactoryCandidateResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/factories/{factory_id}/champion/select:
+    post:
+      tags:
+      - smr
+      - factories
+      summary: Select Factory Champion
+      operationId: select_factory_champion_smr_factories__factory_id__champion_select_post
+      parameters:
+      - name: factory_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Factory Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrFactoryChampionSelectRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmrFactoryChampionDecisionResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/factories/{factory_id}/champion/rollback:
+    post:
+      tags:
+      - smr
+      - factories
+      summary: Rollback Factory Champion
+      operationId: rollback_factory_champion_smr_factories__factory_id__champion_rollback_post
+      parameters:
+      - name: factory_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Factory Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmrFactoryChampionRollbackRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmrFactoryChampionDecisionResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /smr/factories/{factory_id}/champion/events:
+    get:
+      tags:
+      - smr
+      - factories
+      summary: List Factory Champion Events
+      operationId: list_factory_champion_events_smr_factories__factory_id__champion_events_get
+      parameters:
+      - name: factory_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Factory Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SmrFactoryChampionEventResponse'
+                title: Response List Factory Champion Events Smr Factories  Factory
+                  Id  Champion Events Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/managed_research/efforts/proposals:
     get:
       tags:
@@ -6496,48 +6285,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SmrEffortResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/managed_research/efforts/champion-rollback:
-    post:
-      tags:
-      - smr
-      - factories
-      summary: Rollback Champion
-      operationId: rollback_champion_api_v1_managed_research_efforts_champion_rollback_post
-      parameters:
-      - name: factory_id
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Factory Id
-      - name: actor_output_id
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Actor Output Id
-      - name: reason
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Reason
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                title: Response Rollback Champion Api V1 Managed Research Efforts
-                  Champion Rollback Post
         '422':
           description: Validation Error
           content:
@@ -22369,33 +22116,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TagScopeResponse'
-  /api/v1/sdk-logs:
-    post:
-      tags:
-      - sdk-logs
-      summary: Ingest Sdk Logs
-      description: Accept SDK log events and forward them through the BetterStack
-        dispatcher.
-      operationId: ingest_sdk_logs_api_v1_sdk_logs_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SDKLogsIngestRequest'
-        required: true
-      responses:
-        '202':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SDKLogsIngestResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /v1/tunnels/health:
     get:
       tags:
@@ -23158,7 +22878,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Responses Response Id
-      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__delete
+      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__get
       responses:
         '200':
           description: Successful Response
@@ -23169,7 +22889,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Responses Response Id
-      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__delete__delete__1
+      operationId: proxy_openai_responses_response_id_api_managed_agents_openai_v1_responses__response_id__get__delete__1
       responses:
         '200':
           description: Successful Response
@@ -23241,7 +22961,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id
-      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__delete
+      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__post
       responses:
         '200':
           description: Successful Response
@@ -23252,7 +22972,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id
-      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__delete__post__1
+      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__post__post__1
       responses:
         '200':
           description: Successful Response
@@ -23263,7 +22983,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id
-      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__delete__delete__2
+      operationId: proxy_openai_conversations_conversation_id_api_managed_agents_openai_v1_conversations__conversation_id__post__delete__2
       responses:
         '200':
           description: Successful Response
@@ -23298,7 +23018,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id Items Item Id
-      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__delete
+      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__get
       responses:
         '200':
           description: Successful Response
@@ -23309,7 +23029,7 @@ paths:
       tags:
       - managed-agents-openai-proxy
       summary: Proxy Openai Conversations Conversation Id Items Item Id
-      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__delete__delete__1
+      operationId: proxy_openai_conversations_conversation_id_items_item_id_api_managed_agents_openai_v1_conversations__conversation_id__items__item_id__get__delete__1
       responses:
         '200':
           description: Successful Response
@@ -23343,101 +23063,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/GeloLaunchPromoStatusResponse'
   /s/{route_token}/{path}:
-    post:
-      tags:
-      - synthtunnel-public
-      summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post
-      parameters:
-      - name: route_token
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Route Token
-      - name: path
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    options:
-      tags:
-      - synthtunnel-public
-      summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__options__1
-      parameters:
-      - name: route_token
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Route Token
-      - name: path
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__get__2
-      parameters:
-      - name: route_token
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Route Token
-      - name: path
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    delete:
-      tags:
-      - synthtunnel-public
-      summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__delete__3
+      operationId: synthtunnel_gateway_s__route_token___path__get
       parameters:
       - name: route_token
         in: path
@@ -23467,7 +23097,37 @@ paths:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__patch__4
+      operationId: synthtunnel_gateway_s__route_token___path__get__patch__1
+      parameters:
+      - name: route_token
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Route Token
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - synthtunnel-public
+      summary: Synthtunnel Gateway
+      operationId: synthtunnel_gateway_s__route_token___path__get__post__2
       parameters:
       - name: route_token
         in: path
@@ -23497,7 +23157,67 @@ paths:
       tags:
       - synthtunnel-public
       summary: Synthtunnel Gateway
-      operationId: synthtunnel_gateway_s__route_token___path__post__put__5
+      operationId: synthtunnel_gateway_s__route_token___path__get__put__3
+      parameters:
+      - name: route_token
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Route Token
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - synthtunnel-public
+      summary: Synthtunnel Gateway
+      operationId: synthtunnel_gateway_s__route_token___path__get__delete__4
+      parameters:
+      - name: route_token
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Route Token
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    options:
+      tags:
+      - synthtunnel-public
+      summary: Synthtunnel Gateway
+      operationId: synthtunnel_gateway_s__route_token___path__get__options__5
       parameters:
       - name: route_token
         in: path
@@ -24256,7 +23976,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UsageSummaryResponse'
+                $ref: '#/components/schemas/app__api__v1__admin__UsageSummaryResponse'
         '422':
           description: Validation Error
           content:
@@ -29142,36 +28862,6 @@ components:
       - dev_environment_id
       - limit
       title: DevEnvironmentUsageResponse
-    EnqueueInitialRuntimeMessagesRequest:
-      properties:
-        run_id:
-          type: string
-          title: Run Id
-        sender:
-          type: string
-          title: Sender
-        messages:
-          items:
-            additionalProperties: true
-            type: object
-          type: array
-          title: Messages
-      type: object
-      required:
-      - run_id
-      - sender
-      - messages
-      title: EnqueueInitialRuntimeMessagesRequest
-    EnqueueRuntimeMessageRequest:
-      properties:
-        request:
-          additionalProperties: true
-          type: object
-          title: Request
-      type: object
-      required:
-      - request
-      title: EnqueueRuntimeMessageRequest
     EnsureCustomerRequest:
       properties:
         org_id:
@@ -29200,28 +28890,6 @@ components:
       - org_id
       - customer_id
       title: EnsureCustomerResponse
-    EnsureRuntimeSessionRequest:
-      properties:
-        run_id:
-          type: string
-          title: Run Id
-        project_id:
-          type: string
-          title: Project Id
-        target_state:
-          type: string
-          title: Target State
-        checkpoint_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Checkpoint Id
-      type: object
-      required:
-      - run_id
-      - project_id
-      - target_state
-      title: EnsureRuntimeSessionRequest
     EntitlementAssetId:
       type: string
       enum:
@@ -33406,23 +33074,6 @@ components:
           title: Client Metadata
       type: object
       title: PublishManderqueueMessageRequest
-    PublishRuntimeWakeupRequest:
-      properties:
-        run_id:
-          type: string
-          title: Run Id
-        reason:
-          type: string
-          title: Reason
-        trigger:
-          type: string
-          title: Trigger
-          default: manual_wake
-      type: object
-      required:
-      - run_id
-      - reason
-      title: PublishRuntimeWakeupRequest
     QueueSummary:
       properties:
         id:
@@ -34216,28 +33867,6 @@ components:
       - seq
       - action
       title: RuntimeIntentView
-    RuntimeMcpToolCallRequest:
-      properties:
-        run_id:
-          type: string
-          title: Run Id
-        namespace:
-          type: string
-          title: Namespace
-        tool_name:
-          type: string
-          title: Tool Name
-        arguments:
-          additionalProperties: true
-          type: object
-          title: Arguments
-          default: {}
-      type: object
-      required:
-      - run_id
-      - namespace
-      - tool_name
-      title: RuntimeMcpToolCallRequest
     RuntimeMessageMode:
       type: string
       enum:
@@ -34245,109 +33874,6 @@ components:
       - steer
       - control
       title: RuntimeMessageMode
-    SDKLogEntry:
-      properties:
-        level:
-          $ref: '#/components/schemas/Severity'
-        message:
-          type: string
-          maxLength: 4096
-          minLength: 1
-          title: Message
-        timestamp:
-          anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
-          title: Timestamp
-        request_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Request Id
-          description: Optional request identifier supplied by the SDK client.
-        sdk_version:
-          anyOf:
-          - type: string
-            maxLength: 128
-          - type: 'null'
-          title: Sdk Version
-        attributes:
-          additionalProperties: true
-          type: object
-          title: Attributes
-        context:
-          additionalProperties: true
-          type: object
-          title: Context
-          description: Arbitrary structured context specific to the SDK.
-      type: object
-      required:
-      - level
-      - message
-      title: SDKLogEntry
-      description: Single log entry payload sent from the public SDK.
-    SDKLogsIngestRequest:
-      properties:
-        entries:
-          items:
-            $ref: '#/components/schemas/SDKLogEntry'
-          type: array
-          minItems: 1
-          title: Entries
-        batch_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Batch Id
-          description: Optional client-provided identifier for the batch.
-      type: object
-      required:
-      - entries
-      title: SDKLogsIngestRequest
-      description: Batch of log entries delivered in a single call.
-    SDKLogsIngestResponse:
-      properties:
-        accepted:
-          type: integer
-          title: Accepted
-        dispatcher_queue:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Dispatcher Queue
-      type: object
-      required:
-      - accepted
-      title: SDKLogsIngestResponse
-      description: Acknowledge queued log entries.
-    Severity:
-      type: string
-      enum:
-      - debug
-      - info
-      - warning
-      - error
-      - critical
-      title: Severity
-      description: Log severity levels accepted by BetterStack.
-    ShutdownRuntimeSessionRequest:
-      properties:
-        run_id:
-          type: string
-          title: Run Id
-        project_id:
-          type: string
-          title: Project Id
-        target_state:
-          type: string
-          title: Target State
-      type: object
-      required:
-      - run_id
-      - project_id
-      - target_state
-      title: ShutdownRuntimeSessionRequest
     SmrActorControlRequest:
       properties:
         action:
@@ -35159,6 +34685,7 @@ components:
       - gpt-5.3-codex
       - gpt-5.3-codex-spark
       - gpt-5.5
+      - gpt-5.6-luna
       - gpt-5.4-mini
       - nemotron-super
       - deepseek/deepseek-v4-flash
@@ -37278,31 +36805,6 @@ components:
       - digest
       - created_at
       title: SmrEnvironmentResponse
-    SmrEvidenceObligationsRequest:
-      properties:
-        schema:
-          type: string
-          const: smr.evidence_obligations.v1
-          title: Schema
-          default: smr.evidence_obligations.v1
-        required:
-          items:
-            type: string
-            enum:
-            - transcript_rows
-            - task_turn_rows
-            - raw_trace_rows
-            - evidence_packet
-            - terminal_task_rows
-          type: array
-          minItems: 1
-          title: Required
-      additionalProperties: false
-      type: object
-      required:
-      - required
-      title: SmrEvidenceObligationsRequest
-      description: Explicit terminal evidence requirements for proof-bearing run lanes.
     SmrExecutionPreferencesPatchRequest:
       properties:
         preferred_lane:
@@ -37512,18 +37014,6 @@ components:
             type: object
           type: array
           title: Trace Index
-        planning_graph:
-          additionalProperties: true
-          type: object
-          title: Planning Graph
-        project_git:
-          additionalProperties: true
-          type: object
-          title: Project Git
-        inspection:
-          additionalProperties: true
-          type: object
-          title: Inspection
         economics:
           additionalProperties: true
           type: object
@@ -37536,10 +37026,6 @@ components:
           additionalProperties: true
           type: object
           title: Provenance
-        deployment_identity:
-          additionalProperties: true
-          type: object
-          title: Deployment Identity
         artifact_index:
           items:
             additionalProperties: true
@@ -38280,6 +37766,264 @@ components:
       - created_at
       - updated_at
       title: SmrFactoryActorOutputResponse
+    SmrFactoryCandidateGradingRequest:
+      properties:
+        grading:
+          additionalProperties: true
+          type: object
+          title: Grading
+      type: object
+      required:
+      - grading
+      title: SmrFactoryCandidateGradingRequest
+      description: 'Typed intake for a benchmark-owned factorybench.candidate_grading.v1
+
+        record. The backend never grades; it stores what the grader proved.'
+    SmrFactoryCandidateResponse:
+      properties:
+        candidate_id:
+          type: string
+          title: Candidate Id
+        org_id:
+          type: string
+          title: Org Id
+        factory_id:
+          type: string
+          title: Factory Id
+        project_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Project Id
+        effort_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+        run_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Run Id
+        work_product_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Work Product Id
+        candidate_key:
+          type: string
+          title: Candidate Key
+        git_remote:
+          type: string
+          title: Git Remote
+        git_sha:
+          type: string
+          title: Git Sha
+        entrypoint:
+          type: string
+          title: Entrypoint
+        execution_contract_version:
+          type: string
+          title: Execution Contract Version
+        parent_candidate_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Parent Candidate Id
+        grading_target:
+          additionalProperties: true
+          type: object
+          title: Grading Target
+        artifact_ids:
+          items: {}
+          type: array
+          title: Artifact Ids
+        grading_status:
+          type: string
+          enum:
+          - pending
+          - graded
+          - failed
+          - timeout
+          title: Grading Status
+          default: pending
+        grading:
+          additionalProperties: true
+          type: object
+          title: Grading
+        held_out_score:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Held Out Score
+        baseline_score:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Baseline Score
+        graded_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Graded At
+        is_champion:
+          type: boolean
+          title: Is Champion
+          default: false
+        champion_selected_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Champion Selected At
+        published_at:
+          type: string
+          format: date-time
+          title: Published At
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - candidate_id
+      - org_id
+      - factory_id
+      - candidate_key
+      - git_remote
+      - git_sha
+      - entrypoint
+      - execution_contract_version
+      - published_at
+      - created_at
+      - updated_at
+      title: SmrFactoryCandidateResponse
+    SmrFactoryChampionDecisionResponse:
+      properties:
+        action:
+          type: string
+          enum:
+          - promote
+          - rollback
+          - no_lift
+          title: Action
+        reason:
+          type: string
+          title: Reason
+        changed:
+          type: boolean
+          title: Changed
+        champion:
+          anyOf:
+          - $ref: '#/components/schemas/SmrFactoryCandidateResponse'
+          - type: 'null'
+      type: object
+      required:
+      - action
+      - reason
+      - changed
+      title: SmrFactoryChampionDecisionResponse
+    SmrFactoryChampionEventResponse:
+      properties:
+        event_id:
+          type: string
+          title: Event Id
+        org_id:
+          type: string
+          title: Org Id
+        factory_id:
+          type: string
+          title: Factory Id
+        effort_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+        candidate_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Candidate Id
+        action:
+          type: string
+          enum:
+          - promote
+          - rollback
+          - no_lift
+          title: Action
+        git_sha:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Git Sha
+        held_out_score:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Held Out Score
+        baseline_score:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Baseline Score
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+        payload:
+          additionalProperties: true
+          type: object
+          title: Payload
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - event_id
+      - org_id
+      - factory_id
+      - action
+      - created_at
+      title: SmrFactoryChampionEventResponse
+    SmrFactoryChampionRollbackRequest:
+      properties:
+        to_candidate_id:
+          type: string
+          title: To Candidate Id
+        effort_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+        reason:
+          type: string
+          title: Reason
+      type: object
+      required:
+      - to_candidate_id
+      - reason
+      title: SmrFactoryChampionRollbackRequest
+    SmrFactoryChampionSelectRequest:
+      properties:
+        effort_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Effort Id
+        baseline_score:
+          type: number
+          title: Baseline Score
+      type: object
+      required:
+      - baseline_score
+      title: SmrFactoryChampionSelectRequest
     SmrFactoryCreateRequest:
       properties:
         name:
@@ -39347,10 +39091,6 @@ components:
           additionalProperties: true
           type: object
           title: Experiment Observability
-        operator_view:
-          additionalProperties: true
-          type: object
-          title: Operator View
         judgment_state:
           additionalProperties: true
           type: object
@@ -39556,11 +39296,6 @@ components:
         title:
           type: string
           title: Title
-        summary:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Summary
         status:
           type: string
           title: Status
@@ -39572,10 +39307,6 @@ components:
           - type: string
           - type: 'null'
           title: Artifact Id
-        metadata:
-          additionalProperties: true
-          type: object
-          title: Metadata
         created_at:
           type: string
           format: date-time
@@ -43771,6 +43502,14 @@ components:
           title: Worker Pool Id
           description: Optional per-run worker dispatch pool override. When omitted,
             the run uses the project's execution pool configuration.
+        execution_policy:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Execution Policy
+          description: Optional run-scoped execution-policy overlay materialized in
+            this run's immutable config snapshot.
         local_execution:
           anyOf:
           - $ref: '#/components/schemas/SmrLocalExecutionRequest'
@@ -43785,12 +43524,6 @@ components:
           description: Typed product-owned execution profile for first-party Docker
             and Daytona launches. Backend validates host kind, runtime lane, repo
             binding, and materialized image or snapshot before dispatch.
-        evidence_obligations:
-          anyOf:
-          - $ref: '#/components/schemas/SmrEvidenceObligationsRequest'
-          - type: 'null'
-          description: Explicit opt-in terminal evidence requirements for Factory
-            and other proof-bearing run lanes. Ordinary runs leave this unset.
         effort_id:
           anyOf:
           - type: string
@@ -43842,7 +43575,7 @@ components:
           description: Override one shared agent model for this run. Shared top-level
             values are 'baseten/zai-org/GLM-5.2', 'deepseek/deepseek-v4-flash', 'deepseek/deepseek-v4-flash-direct',
             'deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-pro-direct', 'gpt-5.4-mini',
-            'gpt-5.5', 'x-ai/grok-4.3', 'x-ai/grok-build'. Use actor_model_overrides
+            'gpt-5.5', 'gpt-5.6-luna', 'x-ai/grok-4.3', 'x-ai/grok-build'. Use actor_model_overrides
             for actor-specific model selection.
         agent_harness:
           anyOf:
@@ -55489,30 +55222,21 @@ components:
         org_id:
           type: string
           title: Org Id
-        date_range:
-          type: string
-          title: Date Range
-        total_cost_cents:
-          type: integer
-          title: Total Cost Cents
-        total_cost_dollars:
-          type: number
-          title: Total Cost Dollars
-        gpu_events_count:
-          type: integer
-          title: Gpu Events Count
-        total_gpu_seconds:
-          type: number
-          title: Total Gpu Seconds
+        current_month:
+          additionalProperties: true
+          type: object
+          title: Current Month
+        last_30_days:
+          additionalProperties: true
+          type: object
+          title: Last 30 Days
       type: object
       required:
       - org_id
-      - date_range
-      - total_cost_cents
-      - total_cost_dollars
-      - gpu_events_count
-      - total_gpu_seconds
+      - current_month
+      - last_30_days
       title: UsageSummaryResponse
+      description: Response model for usage summary.
     UsageType:
       type: string
       enum:
@@ -56003,6 +55727,35 @@ components:
           title: Fingerprint
       type: object
       title: _SubmitterIn
+    app__api__v1__admin__UsageSummaryResponse:
+      properties:
+        org_id:
+          type: string
+          title: Org Id
+        date_range:
+          type: string
+          title: Date Range
+        total_cost_cents:
+          type: integer
+          title: Total Cost Cents
+        total_cost_dollars:
+          type: number
+          title: Total Cost Dollars
+        gpu_events_count:
+          type: integer
+          title: Gpu Events Count
+        total_gpu_seconds:
+          type: number
+          title: Total Gpu Seconds
+      type: object
+      required:
+      - org_id
+      - date_range
+      - total_cost_cents
+      - total_cost_dollars
+      - gpu_events_count
+      - total_gpu_seconds
+      title: UsageSummaryResponse
     app__api__v1__managed_research__limits__UpdateLimitRequest:
       properties:
         cap_amount:
@@ -56019,26 +55772,6 @@ components:
           title: Policy
       type: object
       title: UpdateLimitRequest
-    app__api__v1__routes_balance__UsageSummaryResponse:
-      properties:
-        org_id:
-          type: string
-          title: Org Id
-        current_month:
-          additionalProperties: true
-          type: object
-          title: Current Month
-        last_30_days:
-          additionalProperties: true
-          type: object
-          title: Last 30 Days
-      type: object
-      required:
-      - org_id
-      - current_month
-      - last_30_days
-      title: UsageSummaryResponse
-      description: Response model for usage summary.
     app__api__v1__routes_usage_overview__UsageSummaryResponse:
       properties:
         total_nominal_usd:


### PR DESCRIPTION
## What

Closes quality-findings SDK#3 (synth-ai half) and completes the deferral noted in #254 ("Out of scope... Vendored `smr_openapi.yaml` still omits the five candidate/champion routes the client calls"). The vendored `synth_ai/managed_research/schemas/smr_openapi.yaml` lagged both backend's committed export and backend's actual routes.

## How

Byte copy of the fresh backend exporter output — the same operation backend's canonical sync (`scripts/validate_smr_openapi.py --write`, `_sync_vendored_contract_artifacts`) performs. Source: `backend/scripts/export_smr_openapi.py` run against the live FastAPI app on a worktree off backend origin/dev (0a5c22fb5), submitted as synth-laboratories/backend#465. Exporter output only; no hand edits. `schemas/public_models.json` untouched (already fixed in #254, including the gpt-5.6 sol/terra projections the backend export does not yet carry).

## Route delta (vendored paths: 694 before -> 685 after)

Added (5) — the routes the SDK already calls:
- `/smr/factories/{factory_id}/candidates`
- `/smr/factories/{factory_id}/candidates/{candidate_id}/grading`
- `/smr/factories/{factory_id}/champion/select`
- `/smr/factories/{factory_id}/champion/rollback`
- `/smr/factories/{factory_id}/champion/events`

Removed (14 stale, absent from backend dev code): 11 `/smr/runtime/control/*` paths plus `/api/v1/managed_research/efforts/champion-rollback`, `/api/v1/sdk-logs`, `/smr/projects/{project_id}/experiments/{experiment_id}/inspect`. Verified the managed-research SDK calls none of the removed routes.

## Verification

`testing@main scripts/validate_synth_ai_contract.py` with `SYNTH_AI_DIR` at this branch and `BACKEND_DIR` at the backend#465 worktree:

```
synth-ai managed-research contract artifacts validated
rc=0
```

Backend-drift check ran (not skipped) and PASSES — vendored snapshot is byte-identical to the backend export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)