### PR TITLE
fix(sdk): py.typed marker, uv-add install copy, regen smr_openapi.yaml with factory routes

### DIFF
--- a/.agents/plugins/managed-research/README.md
+++ b/.agents/plugins/managed-research/README.md
@@ -12,7 +12,7 @@ Local stdio fallback:
 
 - this plugin delegates to the sibling `synth-ai` checkout
 - the maintained stdio entrypoint is `synth-ai-managed-research-mcp`
-- the maintained package install path is `pip install "synth-ai[research]"`
+- the maintained package install path is `uv add "synth-ai[research]"`
 
 Canonical control-plane flow:
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Python SDK and CLI for Synth infrastructure surfaces: tunnels, pools, and hosted
 uv add synth-ai
 ```
 
-Or install with pip:
-
-```bash
-pip install synth-ai
-```
-
 ## Authenticate
 
 Set `SYNTH_API_KEY` before using the SDK or CLI:
@@ -68,7 +62,7 @@ print(client.pools.list())
 Install the research extra when you need hosted runs, projects, Factory Tag, or MCP:
 
 ```bash
-pip install "synth-ai[research]"
+uv add "synth-ai[research]"
 ```
 
 Hero entrypoint — **`SynthClient().research`** only (no standalone control client in new code):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ analytics = [
     "pandas>=2.2.3",
 ]
 research = [
-    # Compatibility extra retained so `pip install synth-ai[research]` remains valid.
+    # Compatibility extra retained so `synth-ai[research]` remains valid.
 ]
 
 [project.urls]
@@ -82,6 +82,7 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 "synth_ai" = [
+    "py.typed",
     "opencode/skill/*/SKILL.md",
     "managed_research/py.typed",
     "managed_research/factory_plans/*.json",

--- a/scripts/generate_sdk_docs.py
+++ b/scripts/generate_sdk_docs.py
@@ -177,7 +177,7 @@ sidebarTitle: Overview
 Install:
 
 ```bash
-pip install "synth-ai[research]"
+uv add "synth-ai[research]"
 ```
 
 Hero entrypoint:


### PR DESCRIPTION
Lands the pre-PyPI SDK debts from QUALITY_FINDINGS_ship_surfaces.md (07-13) on dev for the next 0.15.x patch.

## Changes

1. **Top-level `synth_ai/py.typed`** — previously only `managed_research/py.typed` shipped, so type checkers treated the rest of the SDK as untyped. Added the marker and a `py.typed` entry under `[tool.setuptools.package-data]`. Wheel build verified: both `synth_ai/py.typed` and `synth_ai/managed_research/py.typed` are in the built wheel.
2. **`pip install` → `uv add` sweep** — README.md (dropped the pip alternative block, switched the research-extra copy), `.agents/plugins/managed-research/README.md`, the docs template in `scripts/generate_sdk_docs.py`, and the pyproject compatibility comment. `grep -rn "pip install"` over README/docs/scripts/pyproject is now clean.
3. **Vendored `smr_openapi.yaml` factory routes** — already resolved on dev by d1d52835 ("chore: re-vendor SMR OpenAPI snapshot from backend export"). Verified rather than regenerated: cross-checked all 265 `_request_json` routes in `synth_ai/managed_research/sdk/` against the vendored spec using the same route-extraction regex as backend `scripts/validate_smr_openapi.py` — zero missing, including all five candidate/champion routes (`GET .../candidates`, `POST .../candidates/{id}/grading`, `POST .../champion/select`, `POST .../champion/rollback`, `GET .../champion/events`). Regenerating fresh was skipped deliberately: the local backend checkout sits on a dirty WIP branch and would have snapshotted unreviewed routes.

## Validation

- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — 198 files already formatted
- `uv run python -m build --wheel` — builds; py.typed markers present in wheel
- vendored spec parses (openapi 3.1.0, 685 paths)
- `uv run ty check` — 392 diagnostics, all pre-existing on origin/dev (this diff changes no Python semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)