### PR TITLE
fix(sdk): preserve runtime artifact selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `synth-ai` package are documented here.
 
 ## Unreleased
 
+### Added
+
+- **Runnable-project runtime artifact authority** — `SmrRunnableProjectRequest` preserves an optional `runtime_artifact_release_id` so callers can bind project creation to an exact backend-registered runtime release without bypassing SDK normalization.
+
 ## 0.15.0 — 2026-07-13
 
 ### Added

--- a/synth_ai/managed_research/models/types.py
+++ b/synth_ai/managed_research/models/types.py
@@ -1844,6 +1844,7 @@ class SmrRunnableProjectRequest:
     runtime_kind: SmrRuntimeKind
     environment_kind: SmrEnvironmentKind
     agent_profiles: SmrAgentProfileBindings
+    runtime_artifact_release_id: str | None = None
     worker_profile_ids: list[str] = field(default_factory=list)
     actor_profile_id: str | None = None
     actor_model_assignments: list[SmrActorModelAssignment] = field(default_factory=list)
@@ -1915,6 +1916,9 @@ class SmrRunnableProjectRequest:
                 ),
                 worker_profile_ids=worker_profile_ids,
             ),
+            runtime_artifact_release_id=_optional_string(
+                mapping, "runtime_artifact_release_id"
+            ),
             worker_profile_ids=worker_profile_ids,
             actor_profile_id=_optional_string(mapping, "actor_profile_id"),
             actor_model_assignments=normalize_actor_model_assignments(
@@ -1966,6 +1970,8 @@ class SmrRunnableProjectRequest:
             ]
         if self.actor_profile_id is not None:
             payload["actor_profile_id"] = self.actor_profile_id
+        if self.runtime_artifact_release_id is not None:
+            payload["runtime_artifact_release_id"] = self.runtime_artifact_release_id
         if self.scenario is not None:
             payload["scenario"] = self.scenario
         if self.notes is not None:

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -49930,6 +49930,13 @@ components:
           maxLength: 128
           minLength: 1
           title: Environment Kind
+        runtime_artifact_release_id:
+          anyOf:
+          - type: string
+            maxLength: 200
+            minLength: 1
+          - type: 'null'
+          title: Runtime Artifact Release Id
         orchestrator_profile_id:
           type: string
           maxLength: 200


### PR DESCRIPTION
Carries the optional runtime_artifact_release_id through SmrRunnableProjectRequest normalization and the vendored runnable-project schema. This is the typed SDK half of the Ship 1 Daytona artifact authority; no fallback or raw request bypass. Targeted round-trip probe, Python compilation, and git diff check passed. Tests, CI, Ruff, ty, Docker, and evals were not run per release-window scope.