### PR TITLE
feat(tag): expose typed Factory interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `synth-ai` package are documented here.
 
 ### Added
 
+- **Typed Tag Factory interface** — Tag session creation now requires `TagSessionCreateRequest`; session, watch, receipt, steering, and artifact payloads parse into typed models; and `get_factory_context(scope_id=… | session_id=…)` exposes the current champion, last decision, and candidate counts without raw `/smr/*` reads.
 - **Runnable-project runtime artifact authority** — `SmrRunnableProjectRequest` preserves an optional `runtime_artifact_release_id` so callers can bind project creation to an exact backend-registered runtime release without bypassing SDK normalization.
 - **Canonical cloud slots** — CloudDeployment creation accepts the typed `slot1-cloud` / `slot2-cloud` identity through the SDK and MCP. The `cloud-slot` CLI now addresses deployments by that identity and exposes status, health, claim, heartbeat, fenced deploy/retire, release, and claim-truth workflows. The MCP live proof records the slot, claim id, fencing token, lifecycle, and release receipts.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The CLI also reads `SYNTH_BACKEND_URL` and accepts `--backend-url`.
 
 ```python
 from synth_ai import SynthClient
+from synth_ai.managed_research.models import TagSessionCreateRequest
 
 client = SynthClient()
 
@@ -77,7 +78,13 @@ research = client.research
 limits = research.limits.get()
 
 # Factory Tag loop
-session = research.factories.tag.sessions.create("Improve rollout throughput")
+session = research.factories.tag.sessions.create(
+    TagSessionCreateRequest(
+        request="Improve rollout throughput",
+        factory_id=factory_id,
+        effort_id=effort_id,
+    )
+)
 research.factories.tag.sessions.messages.send(session.session_id, "Status update")
 scope = research.factories.tag.scopes.get_default()
 

--- a/synth_ai/cli/research.py
+++ b/synth_ai/cli/research.py
@@ -71,6 +71,7 @@ def tag_smoke(
 ) -> None:
     """Create a Tag session, send a message, and print scope metadata."""
     from synth_ai import SynthClient
+    from synth_ai.managed_research.models.tag import TagSessionCreateRequest
 
     client = SynthClient(
         api_key=_resolve_api_key(api_key),
@@ -78,9 +79,11 @@ def tag_smoke(
     )
     tag_api = client.research.factories.tag
     session = tag_api.sessions.create(
-        request,
-        factory_id=factory_id,
-        effort_id=effort_id,
+        TagSessionCreateRequest(
+            request=request,
+            factory_id=factory_id,
+            effort_id=effort_id,
+        )
     )
     tag_api.sessions.messages.send(session.session_id, "Smoke check-in")
     scope = tag_api.scopes.get_default()

--- a/synth_ai/managed_research/mcp/tools/tag.py
+++ b/synth_ai/managed_research/mcp/tools/tag.py
@@ -10,6 +10,7 @@ from synth_ai.managed_research.mcp.registry import (
     ToolDefinition,
     tool_schema,
 )
+from synth_ai.managed_research.models.tag import TagSessionCreateRequest
 
 
 def _client(server: Any, args: dict[str, Any]):
@@ -71,7 +72,7 @@ def build_tag_tools(server: Any) -> list[ToolDefinition]:
                 required=["request", "factory_id", "effort_id"],
             ),
             handler=lambda args: _client(server, args).tag.create_session(
-                _tool_body(args, exclude=set())
+                TagSessionCreateRequest(**_tool_body(args, exclude=set()))
             ),
             required_scopes=WRITE_SCOPES,
         ),

--- a/synth_ai/managed_research/models/__init__.py
+++ b/synth_ai/managed_research/models/__init__.py
@@ -449,6 +449,13 @@ from synth_ai.managed_research.models.smr_runtime_kinds import SmrRuntimeKind
 from synth_ai.managed_research.models.smr_tool_providers import SmrToolProvider
 from synth_ai.managed_research.models.smr_work_modes import SmrWorkMode
 from synth_ai.managed_research.models.tag import (
+    TagArtifactKind,
+    TagArtifactLink,
+    TagChampionEventAction,
+    TagFactoryCandidateCounts,
+    TagFactoryChampion,
+    TagFactoryChampionEvent,
+    TagFactoryContext,
     TagMessageRequest,
     TagScope,
     TagSession,
@@ -458,7 +465,9 @@ from synth_ai.managed_research.models.tag import (
     TagSessionReceipt,
     TagSessionStatus,
     TagSessionWatch,
+    TagSteeringReceipt,
     TagSteeringTarget,
+    TagSteeringWikiLink,
     TagTask,
 )
 from synth_ai.managed_research.models.types import (
@@ -916,6 +925,13 @@ __all__ = [
     "TinkerConfig",
     "UsageLimit",
     "StoredFile",
+    "TagArtifactKind",
+    "TagArtifactLink",
+    "TagChampionEventAction",
+    "TagFactoryCandidateCounts",
+    "TagFactoryChampion",
+    "TagFactoryChampionEvent",
+    "TagFactoryContext",
     "TagMessageRequest",
     "TagScope",
     "TagSession",
@@ -925,7 +941,9 @@ __all__ = [
     "TagSessionReceipt",
     "TagSessionStatus",
     "TagSessionWatch",
+    "TagSteeringReceipt",
     "TagSteeringTarget",
+    "TagSteeringWikiLink",
     "TagTask",
     "TaskCollectionSnapshot",
     "TaskSnapshot",

--- a/synth_ai/managed_research/models/tag.py
+++ b/synth_ai/managed_research/models/tag.py
@@ -37,7 +37,19 @@ class TagSessionKind(StrEnum):
     FACTORY_OP = "factory_op"
 
 
-def _mapping(payload: Mapping[str, Any] | dict[str, Any], *, label: str) -> dict[str, Any]:
+class TagArtifactKind(StrEnum):
+    RUN_RECORD = "run_record"
+    RUN_SUMMARY = "run_summary"
+    WORK_PRODUCT = "work_product"
+
+
+class TagChampionEventAction(StrEnum):
+    PROMOTE = "promote"
+    NO_LIFT = "no_lift"
+    ROLLBACK = "rollback"
+
+
+def _mapping(payload: object, *, label: str) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         raise ValueError(f"{label} must be an object")
     return dict(payload)
@@ -74,6 +86,17 @@ def _datetime(payload: Mapping[str, Any], key: str) -> datetime:
     if isinstance(value, str) and value.strip():
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     raise ValueError(f"{key} must be an ISO-8601 datetime")
+
+
+def _optional_datetime(payload: Mapping[str, Any], key: str) -> datetime | None:
+    if payload.get(key) is None:
+        return None
+    return _datetime(payload, key)
+
+
+def _optional_float(payload: Mapping[str, Any], key: str) -> float | None:
+    value = payload.get(key)
+    return float(value) if value is not None else None
 
 
 @dataclass(frozen=True)
@@ -173,13 +196,117 @@ class TagScope:
             updated_at=_datetime(data, "updated_at"),
         )
 
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any] | dict[str, Any]) -> TagScope:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagSteeringWikiLink:
+    changeset_id: str
+    proposal_id: str
+    url: str
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagSteeringWikiLink:
+        data = _mapping(payload, label="TagSteeringWikiLink")
+        return cls(
+            changeset_id=_required_string(data, "changeset_id"),
+            proposal_id=_required_string(data, "proposal_id"),
+            url=_required_string(data, "url"),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagSteeringWikiLink:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagSteeringReceipt:
+    schema_version: str = "tag_steering_receipt.v1"
+    receipt_id: str | None = None
+    session_id: str | None = None
+    org_id: str | None = None
+    factory_id: str | None = None
+    effort_id: str | None = None
+    project_id: str | None = None
+    experiment_id: str | None = None
+    candidate_id: str | None = None
+    run_id: str | None = None
+    steering_target: TagSteeringTarget | None = None
+    message: str | None = None
+    idempotency_key: str | None = None
+    transport_ref: dict[str, Any] = field(default_factory=dict)
+    accepted_at: datetime | None = None
+    wiki: TagSteeringWikiLink | None = None
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagSteeringReceipt:
+        data = _mapping(payload, label="TagSteeringReceipt")
+        steering_target = _optional_string(data, "steering_target")
+        wiki = data.get("wiki")
+        return cls(
+            schema_version=str(data.get("schema_version") or "tag_steering_receipt.v1"),
+            receipt_id=_optional_string(data, "receipt_id"),
+            session_id=_optional_string(data, "session_id"),
+            org_id=_optional_string(data, "org_id"),
+            factory_id=_optional_string(data, "factory_id"),
+            effort_id=_optional_string(data, "effort_id"),
+            project_id=_optional_string(data, "project_id"),
+            experiment_id=_optional_string(data, "experiment_id"),
+            candidate_id=_optional_string(data, "candidate_id"),
+            run_id=_optional_string(data, "run_id"),
+            steering_target=(TagSteeringTarget(steering_target) if steering_target else None),
+            message=_optional_string(data, "message"),
+            idempotency_key=_optional_string(data, "idempotency_key"),
+            transport_ref=dict(data.get("transport_ref") or {}),
+            accepted_at=_optional_datetime(data, "accepted_at"),
+            wiki=TagSteeringWikiLink.from_wire(wiki) if wiki is not None else None,
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagSteeringReceipt:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagArtifactLink:
+    kind: TagArtifactKind
+    url: str
+    schema_version: str = "tag_artifact_link.v1"
+    artifact_id: str | None = None
+    work_product_id: str | None = None
+    title: str | None = None
+    status: str | None = None
+    readiness: str | None = None
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagArtifactLink:
+        data = _mapping(payload, label="TagArtifactLink")
+        return cls(
+            schema_version=str(data.get("schema_version") or "tag_artifact_link.v1"),
+            kind=TagArtifactKind(_required_string(data, "kind")),
+            url=_required_string(data, "url"),
+            artifact_id=_optional_string(data, "artifact_id"),
+            work_product_id=_optional_string(data, "work_product_id"),
+            title=_optional_string(data, "title"),
+            status=_optional_string(data, "status"),
+            readiness=_optional_string(data, "readiness"),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagArtifactLink:
+        return cls.from_wire(payload)
+
 
 @dataclass(frozen=True)
 class TagSessionReceipt:
     state: str
+    schema_version: str = "tag_receipt.v1"
     run_id: str | None = None
     run_url: str | None = None
     artifact_urls: list[str] = field(default_factory=list)
+    artifacts: list[TagArtifactLink] = field(default_factory=list)
     artifact_empty_reason: str | None = None
     terminal_outcome: str | None = None
     project_url: str | None = None
@@ -188,7 +315,7 @@ class TagSessionReceipt:
     experiment_url: str | None = None
     wiki_urls: list[str] = field(default_factory=list)
     git_urls: list[str] = field(default_factory=list)
-    steering_receipts: list[dict[str, Any]] = field(default_factory=list)
+    steering_receipts: list[TagSteeringReceipt] = field(default_factory=list)
 
     @classmethod
     def from_wire(
@@ -198,9 +325,13 @@ class TagSessionReceipt:
         data = dict(payload or {})
         return cls(
             state=str(data.get("state") or "queued"),
+            schema_version=str(data.get("schema_version") or "tag_receipt.v1"),
             run_id=_optional_string(data, "run_id"),
             run_url=_optional_string(data, "run_url"),
             artifact_urls=[str(item) for item in data.get("artifact_urls") or []],
+            artifacts=[
+                TagArtifactLink.from_wire(item) for item in data.get("artifacts") or []
+            ],
             artifact_empty_reason=_optional_string(data, "artifact_empty_reason"),
             terminal_outcome=_optional_string(data, "terminal_outcome"),
             project_url=_optional_string(data, "project_url"),
@@ -210,11 +341,17 @@ class TagSessionReceipt:
             wiki_urls=[str(item) for item in data.get("wiki_urls") or []],
             git_urls=[str(item) for item in data.get("git_urls") or []],
             steering_receipts=[
-                dict(item)
+                TagSteeringReceipt.from_wire(item)
                 for item in data.get("steering_receipts") or []
-                if isinstance(item, Mapping)
             ],
         )
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any] | dict[str, Any] | None,
+    ) -> TagSessionReceipt:
+        return cls.from_wire(payload)
 
 
 @dataclass(frozen=True)
@@ -264,6 +401,10 @@ class TagSession:
             updated_at=_datetime(data, "updated_at"),
         )
 
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any] | dict[str, Any]) -> TagSession:
+        return cls.from_wire(payload)
+
 
 @dataclass(frozen=True)
 class TagTask:
@@ -295,6 +436,10 @@ class TagTask:
             created_at=_datetime(data, "created_at"),
         )
 
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any] | dict[str, Any]) -> TagTask:
+        return cls.from_wire(payload)
+
 
 @dataclass(frozen=True)
 class TagSessionWatch:
@@ -309,10 +454,129 @@ class TagSessionWatch:
             messages=tuple(TagTask.from_wire(item) for item in data.get("messages") or []),
         )
 
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any] | dict[str, Any]
+    ) -> TagSessionWatch:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagFactoryChampion:
+    candidate_id: str
+    git_sha: str
+    work_product_id: str | None = None
+    held_out_score: float | None = None
+    selected_at: datetime | None = None
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagFactoryChampion:
+        data = _mapping(payload, label="TagFactoryChampion")
+        return cls(
+            candidate_id=_required_string(data, "candidate_id"),
+            git_sha=_required_string(data, "git_sha"),
+            work_product_id=_optional_string(data, "work_product_id"),
+            held_out_score=_optional_float(data, "held_out_score"),
+            selected_at=_optional_datetime(data, "selected_at"),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagFactoryChampion:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagFactoryChampionEvent:
+    action: TagChampionEventAction
+    at: datetime
+    candidate_id: str | None = None
+    git_sha: str | None = None
+    held_out_score: float | None = None
+    reason: str | None = None
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagFactoryChampionEvent:
+        data = _mapping(payload, label="TagFactoryChampionEvent")
+        return cls(
+            action=TagChampionEventAction(_required_string(data, "action")),
+            at=_datetime(data, "at"),
+            candidate_id=_optional_string(data, "candidate_id"),
+            git_sha=_optional_string(data, "git_sha"),
+            held_out_score=_optional_float(data, "held_out_score"),
+            reason=_optional_string(data, "reason"),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagFactoryChampionEvent:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagFactoryCandidateCounts:
+    total: int
+    graded: int
+    pending: int
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagFactoryCandidateCounts:
+        data = _mapping(payload, label="TagFactoryCandidateCounts")
+        return cls(
+            total=int(data.get("total") or 0),
+            graded=int(data.get("graded") or 0),
+            pending=int(data.get("pending") or 0),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagFactoryCandidateCounts:
+        return cls.from_wire(payload)
+
+
+@dataclass(frozen=True)
+class TagFactoryContext:
+    factory_id: str
+    candidates: TagFactoryCandidateCounts
+    as_of: datetime
+    schema_version: str = "tag_factory_context.v1"
+    effort_id: str | None = None
+    experiment_ref: str | None = None
+    champion: TagFactoryChampion | None = None
+    last_champion_event: TagFactoryChampionEvent | None = None
+
+    @classmethod
+    def from_wire(cls, payload: object) -> TagFactoryContext:
+        data = _mapping(payload, label="TagFactoryContext")
+        champion = data.get("champion")
+        event = data.get("last_champion_event")
+        return cls(
+            schema_version=str(data.get("schema_version") or "tag_factory_context.v1"),
+            factory_id=_required_string(data, "factory_id"),
+            effort_id=_optional_string(data, "effort_id"),
+            experiment_ref=_optional_string(data, "experiment_ref"),
+            champion=(
+                TagFactoryChampion.from_wire(champion) if champion is not None else None
+            ),
+            last_champion_event=(
+                TagFactoryChampionEvent.from_wire(event) if event is not None else None
+            ),
+            candidates=TagFactoryCandidateCounts.from_wire(data.get("candidates") or {}),
+            as_of=_datetime(data, "as_of"),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: object) -> TagFactoryContext:
+        return cls.from_wire(payload)
+
 
 TagSessionReceiptResponse = TagSessionReceipt
 
 __all__ = [
+    "TagArtifactKind",
+    "TagArtifactLink",
+    "TagChampionEventAction",
+    "TagFactoryCandidateCounts",
+    "TagFactoryChampion",
+    "TagFactoryChampionEvent",
+    "TagFactoryContext",
     "TagMessageRequest",
     "TagScope",
     "TagSession",
@@ -324,5 +588,7 @@ __all__ = [
     "TagSessionStatus",
     "TagSessionWatch",
     "TagSteeringTarget",
+    "TagSteeringReceipt",
+    "TagSteeringWikiLink",
     "TagTask",
 ]

--- a/synth_ai/managed_research/models/tag.py
+++ b/synth_ai/managed_research/models/tag.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 
 class TagSessionStatus(StrEnum):
@@ -52,7 +52,7 @@ class TagChampionEventAction(StrEnum):
 def _mapping(payload: object, *, label: str) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         raise ValueError(f"{label} must be an object")
-    return dict(payload)
+    return dict(cast(Mapping[str, Any], payload))
 
 
 def _optional_mapping(payload: Mapping[str, Any], key: str) -> dict[str, Any] | None:
@@ -329,9 +329,7 @@ class TagSessionReceipt:
             run_id=_optional_string(data, "run_id"),
             run_url=_optional_string(data, "run_url"),
             artifact_urls=[str(item) for item in data.get("artifact_urls") or []],
-            artifacts=[
-                TagArtifactLink.from_wire(item) for item in data.get("artifacts") or []
-            ],
+            artifacts=[TagArtifactLink.from_wire(item) for item in data.get("artifacts") or []],
             artifact_empty_reason=_optional_string(data, "artifact_empty_reason"),
             terminal_outcome=_optional_string(data, "terminal_outcome"),
             project_url=_optional_string(data, "project_url"),
@@ -341,8 +339,7 @@ class TagSessionReceipt:
             wiki_urls=[str(item) for item in data.get("wiki_urls") or []],
             git_urls=[str(item) for item in data.get("git_urls") or []],
             steering_receipts=[
-                TagSteeringReceipt.from_wire(item)
-                for item in data.get("steering_receipts") or []
+                TagSteeringReceipt.from_wire(item) for item in data.get("steering_receipts") or []
             ],
         )
 
@@ -455,9 +452,7 @@ class TagSessionWatch:
         )
 
     @classmethod
-    def from_payload(
-        cls, payload: Mapping[str, Any] | dict[str, Any]
-    ) -> TagSessionWatch:
+    def from_payload(cls, payload: Mapping[str, Any] | dict[str, Any]) -> TagSessionWatch:
         return cls.from_wire(payload)
 
 
@@ -552,9 +547,7 @@ class TagFactoryContext:
             factory_id=_required_string(data, "factory_id"),
             effort_id=_optional_string(data, "effort_id"),
             experiment_ref=_optional_string(data, "experiment_ref"),
-            champion=(
-                TagFactoryChampion.from_wire(champion) if champion is not None else None
-            ),
+            champion=(TagFactoryChampion.from_wire(champion) if champion is not None else None),
             last_champion_event=(
                 TagFactoryChampionEvent.from_wire(event) if event is not None else None
             ),

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -1454,6 +1454,28 @@ class ManagedResearchClient:
             label="get_default_tag_scope",
         )
 
+    def get_tag_scope_factory_context(self, scope_id: str) -> dict[str, Any]:
+        scope_id_value = _require_non_empty_string(scope_id, field_name="scope_id")
+        return _coerce_dict(
+            self._request_json(
+                "GET",
+                f"/api/tag/v1/scopes/{scope_id_value}/factory-context",
+            ),
+            label="get_tag_scope_factory_context",
+        )
+
+    def get_tag_session_factory_context(self, session_id: str) -> dict[str, Any]:
+        session_id_value = _require_non_empty_string(
+            session_id, field_name="session_id"
+        )
+        return _coerce_dict(
+            self._request_json(
+                "GET",
+                f"/api/tag/v1/sessions/{session_id_value}/factory-context",
+            ),
+            label="get_tag_session_factory_context",
+        )
+
     def get_billing_entitlements(self) -> BillingEntitlementSnapshot:
         return self.usage.get_billing_entitlements()
 

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -1465,9 +1465,7 @@ class ManagedResearchClient:
         )
 
     def get_tag_session_factory_context(self, session_id: str) -> dict[str, Any]:
-        session_id_value = _require_non_empty_string(
-            session_id, field_name="session_id"
-        )
+        session_id_value = _require_non_empty_string(session_id, field_name="session_id")
         return _coerce_dict(
             self._request_json(
                 "GET",

--- a/synth_ai/managed_research/sdk/tag.py
+++ b/synth_ai/managed_research/sdk/tag.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from synth_ai.managed_research.models.tag import (
+    TagFactoryContext,
     TagMessageRequest,
     TagScope,
     TagSession,
@@ -20,40 +21,13 @@ from synth_ai.managed_research.sdk._base import _ClientNamespace
 class TagAPI(_ClientNamespace):
     def create_session(
         self,
-        request: TagSessionCreateRequest | Mapping[str, Any] | dict[str, Any] | str,
-        *,
-        definition_of_done: str | None = None,
-        scope_id: str | None = None,
-        factory_id: str | None = None,
-        effort_id: str | None = None,
-        experiment_id: str | None = None,
-        candidate_id: str | None = None,
-        timebox_seconds: int | None = None,
-        runbook_preset: str | None = None,
-        metadata: Mapping[str, Any] | dict[str, Any] | None = None,
+        request: TagSessionCreateRequest,
     ) -> TagSession:
-        if isinstance(request, TagSessionCreateRequest):
-            payload = request.to_wire()
-        elif isinstance(request, str):
-            if not factory_id or not effort_id:
-                raise ValueError("factory_id and effort_id are required for a Tag session")
-            payload = TagSessionCreateRequest(
-                request=request,
-                factory_id=factory_id,
-                effort_id=effort_id,
-                definition_of_done=definition_of_done,
-                scope_id=scope_id,
-                experiment_id=experiment_id,
-                candidate_id=candidate_id,
-                timebox_seconds=timebox_seconds,
-                runbook_preset=runbook_preset,
-                metadata=dict(metadata or {}),
-            ).to_wire()
-        elif isinstance(request, Mapping):
-            payload = dict(request)
-        else:
-            raise TypeError("request must be TagSessionCreateRequest, mapping, or string")
-        return TagSession.from_wire(self._client.create_tag_session(payload))
+        if not isinstance(request, TagSessionCreateRequest):
+            raise TypeError("request must be TagSessionCreateRequest")
+        return TagSession.from_payload(
+            self._client.create_tag_session(request.to_wire())
+        )
 
     def get_session(self, session_id: str) -> TagSession:
         return TagSession.from_wire(self._client.get_tag_session(session_id))
@@ -115,6 +89,20 @@ class TagAPI(_ClientNamespace):
 
     def get_default_scope(self) -> TagScope:
         return TagScope.from_wire(self._client.get_default_tag_scope())
+
+    def get_factory_context(
+        self,
+        *,
+        scope_id: str | None = None,
+        session_id: str | None = None,
+    ) -> TagFactoryContext:
+        if (scope_id is None) == (session_id is None):
+            raise ValueError("exactly one of scope_id or session_id is required")
+        if scope_id is not None:
+            payload = self._client.get_tag_scope_factory_context(scope_id)
+        else:
+            payload = self._client.get_tag_session_factory_context(str(session_id))
+        return TagFactoryContext.from_payload(payload)
 
 
 __all__ = ["TagAPI"]

--- a/synth_ai/managed_research/sdk/tag.py
+++ b/synth_ai/managed_research/sdk/tag.py
@@ -25,9 +25,7 @@ class TagAPI(_ClientNamespace):
     ) -> TagSession:
         if not isinstance(request, TagSessionCreateRequest):
             raise TypeError("request must be TagSessionCreateRequest")
-        return TagSession.from_payload(
-            self._client.create_tag_session(request.to_wire())
-        )
+        return TagSession.from_payload(self._client.create_tag_session(request.to_wire()))
 
     def get_session(self, session_id: str) -> TagSession:
         return TagSession.from_wire(self._client.get_tag_session(session_id))

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -15,6 +15,7 @@ from synth_ai.managed_research.models.factories import (
     FactoryChampionSelectRequest,
 )
 from synth_ai.managed_research.models.tag import (
+    TagFactoryContext,
     TagMessageRequest,
     TagScope,
     TagSession,
@@ -77,55 +78,30 @@ class ResearchFactoriesTagSessionsAPI:
 
     def create(
         self,
-        request: TagSessionCreateRequest | Mapping[str, Any] | dict[str, Any] | str,
-        *,
-        definition_of_done: str | None = None,
-        scope_id: str | None = None,
-        factory_id: str | None = None,
-        effort_id: str | None = None,
-        experiment_id: str | None = None,
-        candidate_id: str | None = None,
-        timebox_seconds: int | None = None,
-        runbook_preset: str | None = None,
-        metadata: Mapping[str, Any] | dict[str, Any] | None = None,
+        request: TagSessionCreateRequest,
     ) -> TagSession:
         """Start a Factory Tag session for a one-off research task.
 
         Args:
-            request: ``TagSessionCreateRequest``, mapping, or primary request
-                string shown to the Tag worker.
-            definition_of_done: Optional explicit DoD text.
-            scope_id: Optional Tag scope override (defaults via ``scopes``).
-            timebox_seconds: Optional wall-clock cap for the session.
-            runbook_preset: Optional runbook preset slug.
-            metadata: Optional session metadata.
+            request: Fully typed Tag session request.
 
         Returns:
             Created ``TagSession`` with ids needed for ``messages.send``.
 
         Example:
             session = research.factories.tag.sessions.create(
-                "Summarize test failures",
-                factory_id=factory_id,
-                effort_id=effort_id,
+                TagSessionCreateRequest(
+                    request="Summarize test failures",
+                    factory_id=factory_id,
+                    effort_id=effort_id,
+                )
             )
             research.factories.tag.sessions.messages.send(
                 session.session_id,
                 "Return a bullet list of root causes.",
             )
         """
-        return self._session.tag.create_session(
-            request,
-            definition_of_done=definition_of_done,
-            scope_id=scope_id,
-            factory_id=factory_id,
-            effort_id=effort_id,
-            experiment_id=experiment_id,
-            candidate_id=candidate_id,
-            timebox_seconds=timebox_seconds,
-            runbook_preset=runbook_preset,
-            metadata=metadata,
-        )
+        return self._session.tag.create_session(request)
 
     def get(self, session_id: str) -> TagSession:
         """Fetch the current Tag session state and terminal receipt fields."""
@@ -181,6 +157,10 @@ class ResearchFactoriesTagSessionsAPI:
         """
         return self._session.tag.control_session(session_id, action)
 
+    def get_factory_context(self, session_id: str) -> TagFactoryContext:
+        """Read the Factory champion and candidate context bound to a session."""
+        return self._session.tag.get_factory_context(session_id=session_id)
+
 
 class ResearchFactoriesTagScopesAPI:
     """Resolve default Tag scopes for an organization."""
@@ -191,6 +171,10 @@ class ResearchFactoriesTagScopesAPI:
     def get_default(self) -> TagScope:
         """Return the org default Tag scope used when ``scope_id`` is omitted."""
         return self._session.tag.get_default_scope()
+
+    def get_factory_context(self, scope_id: str = "default") -> TagFactoryContext:
+        """Read Factory champion and candidate context for a Tag scope."""
+        return self._session.tag.get_factory_context(scope_id=scope_id)
 
 
 class ResearchFactoriesTagAPI:


### PR DESCRIPTION
Adds typed Tag Factory context, receipt, steering, and artifact models; typed-only session creation; scope/session factory-context reads; MCP and maintained caller compatibility; README and changelog updates. Paired backend authority: backend PR #524 / merge 04f25a06bf5cc6e35fdc298861f0199748cd69be. Validation: focused compile, representative payload parsing, signature and hard-fail probes, MCP typed handler construction, diff check, and green headless review artifact 20260715T040545Z-synth-ai.md. Per operator instruction, no tests, Ruff, or ty were run locally.