### PR TITLE
fix(research): follow WorkProduct content redirects

### DIFF
--- a/synth_ai/managed_research/transport/http.py
+++ b/synth_ai/managed_research/transport/http.py
@@ -207,6 +207,11 @@ class SmrHttpTransport:
             base_url=self.base_url.rstrip("/"),
             headers=self.headers,
             timeout=self.timeout,
+            # WorkProduct content resolves through the durable artifact owner.
+            # The API first redirects to its artifact route and may then redirect
+            # to presigned object storage; returning the first 3xx body would
+            # silently surface empty content instead of the stored blob.
+            follow_redirects=True,
         )
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary

Follow redirects in the Managed Research HTTP transport so typed WorkProduct content reads reach the durable artifact body.

## Why

The WorkProduct content route redirects to the artifact route and may then redirect to presigned object storage. Without redirect following, `request_bytes` treats the first 3xx as a successful empty body and reports misleading unreadable content.

## Validation

- Python compilation — passed
- `git diff --check` — passed

Not run: tests, Ruff, ty, broad suites, local stack, or paid eval.

## Dependency

Pairs with the backend durable WorkProduct content-authority PR.
