### PR TITLE
fix(sdk): preserve image upload signature

### DIFF
--- a/synth_ai/managed_research/sdk/image_releases.py
+++ b/synth_ai/managed_research/sdk/image_releases.py
@@ -422,7 +422,6 @@ class ImageReleasesAPI(_ClientNamespace):
                             upload["upload_url"],
                             content=handle,
                             headers={
-                                "Content-Type": "application/x-tar",
                                 "Content-Length": str(normalized["archive_size_bytes"]),
                             },
                         )


### PR DESCRIPTION
Removes the unsigned Content-Type header from the Synth-managed image release presigned PUT. Content-Length, digest/size preflight, redirect refusal, and exact-key retry behavior remain unchanged.\n\nValidation:\n- python3 -m py_compile synth_ai/managed_research/sdk/image_releases.py\n- git diff --check\n\nNo tests, Ruff, ty, or live upload were run.