### PR TITLE
release: prepare synth-ai 0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.15.0-orange synth-ai==0.15.0 -->
+<!-- CI release pins: PyPI-0.15.1-orange synth-ai==0.15.1 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/managed_research/factory_standup.py
+++ b/synth_ai/managed_research/factory_standup.py
@@ -1259,9 +1259,7 @@ def _confirm_wake_preview(
         confirmed_preview_token=preview.preview_token,
     )
     if result.confirmed_preview_id != preview.preview_id or result.receipt_id is None:
-        raise RuntimeError(
-            "wake receipt is not durably bound to the confirmed preview"
-        )
+        raise RuntimeError("wake receipt is not durably bound to the confirmed preview")
     return result
 
 
@@ -1338,14 +1336,8 @@ def execute_factory_standup(
             factory.factory_id,
             **_wake_due_preview_kwargs(plan),
         )
-        if (
-            wake_due_launch
-            and wake_preview.ready > 0
-            and not wake_preview.confirmation_required
-        ):
-            raise RuntimeError(
-                "wake preview has ready work but is not confirmation-ready"
-            )
+        if wake_due_launch and wake_preview.ready > 0 and not wake_preview.confirmation_required:
+            raise RuntimeError("wake preview has ready work but is not confirmation-ready")
         wake_result = (
             _confirm_wake_preview(
                 client=client,
@@ -1365,9 +1357,7 @@ def execute_factory_standup(
         "created_project": _jsonable(created_project),
         "project_link": _jsonable(link),
         "efforts": _jsonable(efforts),
-        "wake_due_preview": (
-            _wake_result_proof(wake_preview) if wake_due_launch else None
-        ),
+        "wake_due_preview": (_wake_result_proof(wake_preview) if wake_due_launch else None),
         "wake_due": _wake_result_proof(wake_result),
         "status": _jsonable(client.factories.status(factory.factory_id)),
     }

--- a/synth_ai/managed_research/mcp/server.py
+++ b/synth_ai/managed_research/mcp/server.py
@@ -1097,14 +1097,10 @@ class ManagedResearchMcpServer:
                 dry_run=False,
                 continue_on_error=contract.continue_on_error,
                 confirmed_preview_id=preview_id,
-                confirmed_preview_token=require_string(
-                    args, "confirmed_preview_token"
-                ),
+                confirmed_preview_token=require_string(args, "confirmed_preview_token"),
             )
             if result.confirmed_preview_id != preview_id or result.receipt_id is None:
-                raise RuntimeError(
-                    "wake receipt is not durably bound to the confirmed preview"
-                )
+                raise RuntimeError("wake receipt is not durably bound to the confirmed preview")
             return result.raw
 
     def _tool_list_factory_efforts(self, args: JSONDict) -> Any:

--- a/synth_ai/managed_research/mcp/tools/factories.py
+++ b/synth_ai/managed_research/mcp/tools/factories.py
@@ -746,9 +746,7 @@ def build_factory_tools(server: Any) -> list[ToolDefinition]:
                     "factory_id": {"type": "string", "description": "Factory ID."},
                     "preview_id": {
                         "type": "string",
-                        "description": (
-                            "preview_id returned by smr_preview_factory_wake."
-                        ),
+                        "description": ("preview_id returned by smr_preview_factory_wake."),
                     },
                     "request_contract": {
                         "type": "object",

--- a/synth_ai/managed_research/models/factories.py
+++ b/synth_ai/managed_research/models/factories.py
@@ -1951,18 +1951,13 @@ class FactoryWakeDueRequest:
         unknown_keys = sorted(str(key) for key in set(mapping) - allowed_keys)
         if unknown_keys:
             raise ValueError(
-                "factory wake request contract contains unknown fields: "
-                + ", ".join(unknown_keys)
+                "factory wake request contract contains unknown fields: " + ", ".join(unknown_keys)
             )
         contract = cls.from_wire(mapping)
         canonical_contract = contract.to_contract_wire()
-        replayed_fields = {
-            str(key): canonical_contract[str(key)] for key in mapping
-        }
+        replayed_fields = {str(key): canonical_contract[str(key)] for key in mapping}
         if dict(mapping) != replayed_fields:
-            raise ValueError(
-                "factory wake request contract must be replayed exactly as returned"
-            )
+            raise ValueError("factory wake request contract must be replayed exactly as returned")
         return contract
 
     @classmethod
@@ -1982,27 +1977,23 @@ class FactoryWakeDueRequest:
         continue_on_error = _optional_bool(mapping, "continue_on_error")
         return cls(
             launch_request=(
-                dict(launch_request) if isinstance(launch_request, Mapping) else None
+                _optional_object_dict(launch_request, label="factory wake launch_request")
+                if launch_request is not None
+                else None
             ),
             limit=limit,
             allow_overlap=bool(_optional_bool(mapping, "allow_overlap")),
             dry_run=bool(_optional_bool(mapping, "dry_run")),
-            continue_on_error=(
-                True if continue_on_error is None else continue_on_error
-            ),
+            continue_on_error=(True if continue_on_error is None else continue_on_error),
             confirmed_preview_id=_optional_string(mapping, "confirmed_preview_id"),
-            confirmed_preview_token=_optional_string(
-                mapping, "confirmed_preview_token"
-            ),
+            confirmed_preview_token=_optional_string(mapping, "confirmed_preview_token"),
         )
 
     def to_contract_wire(self) -> dict[str, Any]:
         """Return the token-bound request fields, excluding transport controls."""
         payload: dict[str, Any] = {
             "launch_request": (
-                dict(self.launch_request)
-                if self.launch_request is not None
-                else None
+                dict(self.launch_request) if self.launch_request is not None else None
             ),
             "limit": self.limit,
             "allow_overlap": self.allow_overlap,
@@ -2092,13 +2083,9 @@ class FactoryWakeDueResult:
             preview_token=_optional_string(mapping, "preview_token"),
             preview_expires_at=_optional_datetime(mapping, "preview_expires_at"),
             confirmed_preview_id=_optional_string(mapping, "confirmed_preview_id"),
-            confirmation_required=bool(
-                _optional_bool(mapping, "confirmation_required")
-            ),
+            confirmation_required=bool(_optional_bool(mapping, "confirmation_required")),
             request_contract=(
-                FactoryWakeDueRequest.from_contract_wire(
-                    mapping.get("request_contract")
-                )
+                FactoryWakeDueRequest.from_contract_wire(mapping.get("request_contract"))
                 if mapping.get("request_contract") is not None
                 else None
             ),

--- a/synth_ai/managed_research/sdk/factories.py
+++ b/synth_ai/managed_research/sdk/factories.py
@@ -702,10 +702,9 @@ class FactoriesAPI(_ClientNamespace):
         decision_note: str | None = None,
         budget_policy: Mapping[str, Any] | dict[str, Any] | None = None,
         publication_policy: Mapping[str, Any] | dict[str, Any] | None = None,
-        authorization_policy: AuthorizationPolicy
-        | Mapping[str, Any]
-        | dict[str, Any]
-        | None = None,
+        authorization_policy: (
+            AuthorizationPolicy | Mapping[str, Any] | dict[str, Any] | None
+        ) = None,
         actor_notes: Mapping[str, Any] | dict[str, Any] | None = None,
         metadata: Mapping[str, Any] | dict[str, Any] | None = None,
     ) -> Effort:
@@ -774,13 +773,9 @@ class FactoriesAPI(_ClientNamespace):
         confirmed_preview_token: str | None = None,
     ) -> FactoryWakeDueResult:
         """Preview due work or execute it with the corresponding signed token."""
-        if dry_run and (
-            confirmed_preview_id is not None or confirmed_preview_token is not None
-        ):
+        if dry_run and (confirmed_preview_id is not None or confirmed_preview_token is not None):
             raise ValueError("Factory wake previews do not accept confirmation fields")
-        if not dry_run and (
-            confirmed_preview_id is None or confirmed_preview_token is None
-        ):
+        if not dry_run and (confirmed_preview_id is None or confirmed_preview_token is None):
             raise ValueError(
                 "Factory wake execution requires the preview_id and preview_token "
                 "returned by a dry-run preview"

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -368,9 +368,7 @@ class ResearchFactoriesAPI:
             confirmed_preview_token=preview.preview_token,
         )
         if result.confirmed_preview_id != preview.preview_id or result.receipt_id is None:
-            raise RuntimeError(
-                "wake receipt is not durably bound to the confirmed preview"
-            )
+            raise RuntimeError("wake receipt is not durably bound to the confirmed preview")
         return result
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- reserve `0.15.1` for the integrated Research Factory preview/confirm/recovery SDK
- align the README CI release pin and lockfile package identity

## Candidate evidence

- Source parent: `c6c6180d9cc847a58d3c3b226953aad2100c4b50`
- Wheel: `synth_ai-0.15.1-py3-none-any.whl`
- Wheel SHA-256: `2d8b451a75e4b0ea642803164da46ec9483dc1d0e4ba4b161a1bed859c14faea`
- sdist SHA-256: `5eb4d9ca3abb41ba7131ad19709544d81ae03afff84da23cdbcea24177220b2c`
- Clean install verified version, Research preview/confirm methods, managed wake method, and MCP console entrypoint
- `git diff --check` passed

This PR targets `dev`; publishing remains gated on the coordinated staging and launch checklist. No tests, Ruff, or ty were run.
