### PR TITLE
fix(research): publish 0.15.2 schema parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `synth-ai` package are documented here.
 
 ## Unreleased
 
+## 0.15.2 — 2026-07-17
+
+### Fixed
+
+- **Research run authority schema parity** — the vendored backend OpenAPI now
+  carries the optional `runtime_authority_source_version` field returned by
+  typed run-authority readouts, keeping the published SDK contract aligned with
+  the Research Factory backend release.
+- **Installed schema completeness** — source and wheel distributions now retain
+  the backend-authored public-model registry beside the vendored OpenAPI schema.
+
 ## 0.15.1 — 2026-07-17
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,9 @@ recursive-exclude synth_ai *.tar
 # The built-in Factory standup plans are lightweight runtime resources. Keep
 # them in source and wheel distributions after excluding other JSON datasets.
 recursive-include synth_ai/managed_research/factory_plans *.json
+# The backend-authored public model registry is part of the vendored Research
+# contract and must remain inspectable from an installed SDK.
+include synth_ai/managed_research/schemas/public_models.json
 global-exclude *.pyc
 global-exclude __pycache__
 global-exclude .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.15.1-orange synth-ai==0.15.1 -->
+<!-- CI release pins: PyPI-0.15.2-orange synth-ai==0.15.2 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.15.1"
+version = "0.15.2"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -29143,14 +29143,14 @@ components:
         topology_id:
           type: string
           title: Topology Id
+        host_kind:
+          type: string
+          title: Host Kind
         topology_version:
           anyOf:
           - type: string
           - type: 'null'
           title: Topology Version
-        host_kind:
-          type: string
-          title: Host Kind
         metadata:
           additionalProperties: true
           type: object
@@ -37318,6 +37318,11 @@ components:
         source_authority_version:
           type: string
           title: Source Authority Version
+        runtime_authority_source_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Runtime Authority Source Version
         public_status:
           anyOf:
           - additionalProperties: true

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -4062,14 +4062,14 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         return payload
 
     def get_image_release(self, *, release_id: str) -> ImageRelease:
-        normalized_release_id = _require_non_empty_string(
+        release_id = _require_non_empty_string(
             release_id,
             field_name="release_id",
         )
         return _image_release_from_wire(
             self._request_json(
                 "GET",
-                f"/smr/v1/image-releases/{normalized_release_id}",
+                f"/smr/v1/image-releases/{release_id}",
             )
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Scope

- Publish synth-ai 0.15.2 from the current dev line.
- Vendor the backend-owned Managed Research OpenAPI and public-model snapshots from backend PR #645 exact head `78857d2ecc065e607cc0f10c166f6f19976bef05`.
- Carry `runtime_authority_source_version` in the installed run-authority schema.
- Retain `public_models.json` in source and wheel distributions.
- Preserve the built-in RSI Synth-on-Synth Factory plan and the 549-tool MCP surface.

## Exact-head evidence

Candidate: `b17f8215c62115400a965150bfdfefa271b32a03`

- Canonical backend command `uv run python scripts/validate_smr_openapi.py --repo synth-ai --write`: generated the vendored contract from the exact backend head.
- Canonical parity validation without `--write`: passed for synth-ai.
- SDK architecture guard: passed.
- Python-only/no-Rust guard: passed.
- Exact-source CPython 3.11 sdist and wheel build: passed.
- Wheel inventory: includes `rsi_synth_on_synth.plan.json`, `smr_openapi.yaml`, and `public_models.json`.
- Clean CPython 3.11 wheel install: version 0.15.2; `SynthClient().research` imports; six typed Research errors import; built-in RSI plan loads; `runtime_authority_source_version` is present; public model snapshot loads; 549/549 MCP tool names are unique; MCP entrypoint is installed.
- `git diff --check`: passed.

Feature wheel SHA-256: `d1b31e17e4481085e511c9b46a3333ecf6513ef01a14b527aa4260ce28b0cb7b`

Feature sdist SHA-256: `ad0a482c1ce2b6c912ecf59b73b572fe7134a9bf60cbeba1897a2e6ee57b8bae`

Ruff and ty were not run locally per operator instruction; the required exact-head GitHub gates must be green before merge.
