### PR TITLE
chore(release): promote synth-ai 0.15.2 to nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `synth-ai` package are documented here.
 
 ## Unreleased
 
+## 0.15.2 — 2026-07-17
+
+### Fixed
+
+- **Research run authority schema parity** — the vendored backend OpenAPI now
+  carries the optional `runtime_authority_source_version` field returned by
+  typed run-authority readouts, keeping the published SDK contract aligned with
+  the Research Factory backend release.
+- **Installed schema completeness** — source and wheel distributions now retain
+  the backend-authored public-model registry beside the vendored OpenAPI schema.
+
 ## 0.15.1 — 2026-07-17
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,9 @@ recursive-exclude synth_ai *.tar
 # The built-in Factory standup plans are lightweight runtime resources. Keep
 # them in source and wheel distributions after excluding other JSON datasets.
 recursive-include synth_ai/managed_research/factory_plans *.json
+# The backend-authored public model registry is part of the vendored Research
+# contract and must remain inspectable from an installed SDK.
+include synth_ai/managed_research/schemas/public_models.json
 global-exclude *.pyc
 global-exclude __pycache__
 global-exclude .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.15.1-orange synth-ai==0.15.1 -->
+<!-- CI release pins: PyPI-0.15.2-orange synth-ai==0.15.2 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.15.1"
+version = "0.15.2"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -29143,14 +29143,14 @@ components:
         topology_id:
           type: string
           title: Topology Id
+        host_kind:
+          type: string
+          title: Host Kind
         topology_version:
           anyOf:
           - type: string
           - type: 'null'
           title: Topology Version
-        host_kind:
-          type: string
-          title: Host Kind
         metadata:
           additionalProperties: true
           type: object
@@ -37318,6 +37318,11 @@ components:
         source_authority_version:
           type: string
           title: Source Authority Version
+        runtime_authority_source_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Runtime Authority Source Version
         public_status:
           anyOf:
           - additionalProperties: true

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -4062,14 +4062,14 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         return payload
 
     def get_image_release(self, *, release_id: str) -> ImageRelease:
-        normalized_release_id = _require_non_empty_string(
+        release_id = _require_non_empty_string(
             release_id,
             field_name="release_id",
         )
         return _image_release_from_wire(
             self._request_json(
                 "GET",
-                f"/smr/v1/image-releases/{normalized_release_id}",
+                f"/smr/v1/image-releases/{release_id}",
             )
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Promotion

Reconcile current `dev` into `nightly` for synth-ai 0.15.2.

- Head: `c72ab6229dda1c26c6fde9a497418b8fce3fadfa`
- Parents: prior nightly `d7f885d0c77ded24313de7171439c01554a55416`; dev `30558cf95edbab460b00a3bc7be24e8e8fef243d`
- Feature source `b17f8215c62115400a965150bfdfefa271b32a03` is reachable from this head.
- Version and README both resolve 0.15.2.
- `git diff --check` passed.

Feature evidence is recorded on #281. This promotion must pass all five exact-head GitHub CI gates before merge.

Ruff and ty were not run locally per operator instruction.
