### PR TITLE
chore(release): promote synth-ai 0.15.2 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `synth-ai` package are documented here.
 
 ## Unreleased
 
+## 0.15.2 — 2026-07-17
+
+### Fixed
+
+- **Research run authority schema parity** — the vendored backend OpenAPI now
+  carries the optional `runtime_authority_source_version` field returned by
+  typed run-authority readouts, keeping the published SDK contract aligned with
+  the Research Factory backend release.
+- **Installed schema completeness** — source and wheel distributions now retain
+  the backend-authored public-model registry beside the vendored OpenAPI schema.
+
 ## 0.15.1 — 2026-07-17
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,9 @@ recursive-exclude synth_ai *.tar
 # The built-in Factory standup plans are lightweight runtime resources. Keep
 # them in source and wheel distributions after excluding other JSON datasets.
 recursive-include synth_ai/managed_research/factory_plans *.json
+# The backend-authored public model registry is part of the vendored Research
+# contract and must remain inspectable from an installed SDK.
+include synth_ai/managed_research/schemas/public_models.json
 global-exclude *.pyc
 global-exclude __pycache__
 global-exclude .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.15.1-orange synth-ai==0.15.1 -->
+<!-- CI release pins: PyPI-0.15.2-orange synth-ai==0.15.2 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.15.1"
+version = "0.15.2"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -29143,14 +29143,14 @@ components:
         topology_id:
           type: string
           title: Topology Id
+        host_kind:
+          type: string
+          title: Host Kind
         topology_version:
           anyOf:
           - type: string
           - type: 'null'
           title: Topology Version
-        host_kind:
-          type: string
-          title: Host Kind
         metadata:
           additionalProperties: true
           type: object
@@ -37318,6 +37318,11 @@ components:
         source_authority_version:
           type: string
           title: Source Authority Version
+        runtime_authority_source_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Runtime Authority Source Version
         public_status:
           anyOf:
           - additionalProperties: true

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -4062,14 +4062,14 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         return payload
 
     def get_image_release(self, *, release_id: str) -> ImageRelease:
-        normalized_release_id = _require_non_empty_string(
+        release_id = _require_non_empty_string(
             release_id,
             field_name="release_id",
         )
         return _image_release_from_wire(
             self._request_json(
                 "GET",
-                f"/smr/v1/image-releases/{normalized_release_id}",
+                f"/smr/v1/image-releases/{release_id}",
             )
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Promotion

Reconcile current `nightly` into `main` and publish synth-ai 0.15.2.

- Head: `b00765295c00457cc51e878591f22cd17852523e`
- Parents: published 0.15.1 main `c683d8c380622a22c403db7f762692f52b81121b`; nightly `38c10c4be1d3a76ab85fa150b927b86c4a8b9f0e`
- Feature source `b17f8215c62115400a965150bfdfefa271b32a03` is reachable from this head.
- Version and README both resolve 0.15.2.
- `git diff --check` passed.

Evidence chain:

- Feature #281: exact-head 5/5 CI green; backend-owned schema parity, package build, and clean CPython 3.11 wheel acceptance passed.
- Nightly #282: exact-head 5/5 CI green.
- This promotion must pass all five exact-head GitHub CI gates before merge.

Merging to main triggers the authoritative trusted-publisher workflow. The release is complete only after PyPI 0.15.2, tag/release artifacts, hashes, and a fresh official install are verified.

Ruff and ty were not run locally per operator instruction.
