### PR TITLE
fix(smr): stop repr leaking API key; map MCP denials for all tools

### DIFF
--- a/synth_ai/managed_research/mcp/server.py
+++ b/synth_ai/managed_research/mcp/server.py
@@ -3474,6 +3474,22 @@ class ManagedResearchMcpServer:
                 "id": request_id,
                 "error": {"code": exc.code, "message": exc.message, "data": exc.data},
             }
+        except SmrApiError as exc:
+            # Central denial mapping: any tool (not just the run-launch handlers)
+            # that raises a typed SmrApiError must surface the structured
+            # error_code / http_status / detail so SDK↔MCP denial parity holds.
+            # Without this, non-launch tools flatten to a generic -32000 text
+            # error and drop plan/cap/current-count fields.
+            payload = _mcp_structured_trigger_error_payload(exc)
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32010,
+                    "message": payload.get("message", str(exc)),
+                    "data": payload,
+                },
+            }
         except Exception as exc:
             return {
                 "jsonrpc": "2.0",

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -1117,7 +1117,7 @@ def _code_bundle_upload_payload(
 class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
     """Managed Research client implementation."""
 
-    api_key: str | None = None
+    api_key: str | None = field(default=None, repr=False)
     backend_base: str | None = None
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
     _transport: SmrHttpTransport = field(init=False, repr=False)
@@ -1175,6 +1175,16 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
             api_key=resolved_api_key,
             backend_base=resolved_backend_base,
             timeout_seconds=self.timeout_seconds,
+        )
+
+    def __repr__(self) -> str:
+        # Never render the raw API key: the resolved secret lives on self.api_key
+        # after __post_init__, so the default dataclass repr / %r / traceback frame
+        # would otherwise leak a live credential into logs.
+        api_key_state = "set" if self.api_key else "unset"
+        return (
+            f"ManagedResearchClient(backend_base={self.backend_base!r}, "
+            f"timeout_seconds={self.timeout_seconds!r}, api_key=<{api_key_state}>)"
         )
 
     def __enter__(self) -> ManagedResearchClient:


### PR DESCRIPTION
## Why

Two launch-blocking code defects surfaced while auditing the Managed Research **access/limits customer-journey** launch packet. Both are on the published customer SDK surface; the currently-published `0.15.2` still has defect #1.

## Fixes

**1. `repr(ManagedResearchClient)` leaked the live API key** (launch checklist §14 "no raw secrets"; the "P1 OWED" from the 07-16 factory-launch session).
`api_key` was a plain dataclass field, and `__post_init__` overwrites it with the *resolved* secret (pulled from env when not passed) — so the auto-generated dataclass `repr` rendered the live key into any log line, `%r`, or traceback frame. Also reachable via `SynthClient().research.session`.
Fix: `api_key = field(default=None, repr=False)` + an explicit redacting `__repr__` (`api_key=<set|unset>`).

**2. MCP denial-parity gap** (Handoff 04 P3/P4).
The dispatch mapped typed `SmrApiError` denials to structured RPC errors for only the four run-launch handlers; every other tool (`smr_get_limits`, resource-limit extension, …) flattened to a generic `-32000` text error, dropping `error_code` / `http_status` / `detail`.
Fix: a central `except SmrApiError` in `_handle_message` that emits `-32010` + structured `data` for any tool.

## Verification

Ran in a clean `dev` worktree (source-only diff, 2 files):
- `repr` / `str` / `%r` of a client built with a fake `sk-live-…` key never contain the key; render shows `api_key=<set>`.
- A non-launch tool (`smr_get_limits`) raising a typed 429 now returns `-32010` with `error=smr_concurrent_run_limit_exceeded`, `http_status=429`, `detail.cap=5`, `detail.plan=pro`.

The matching regression tests belong in the private `synth-laboratories/testing` `backend/unit/synth_ai_sdk/` suite (synth-ai does not host tests in-repo); tracked as a follow-up since that repo is mid-reorg. Verified content is recorded in the audit note beside the launch handoff packet.

## Notes
- Source-only; no unrelated WIP included.
- These fixes must ride the next `synth-ai` publish to reach the customer wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)