### PR TITLE
chore(release): publish .dev prereleases from dev; bump 0.15.3.dev0

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -2,7 +2,9 @@ name: Auto-publish to PyPI
 
 on:
   push:
-    branches: [main]
+    # main publishes stable versions; dev publishes .dev prereleases so the
+    # latest fixes are installable (with --pre / an exact pin) before promotion.
+    branches: [main, dev]
 
 permissions:
   contents: write
@@ -34,25 +36,22 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Local version: $VERSION"
 
-      - name: Get PyPI version
-        id: pypi
-        run: |
-          PYPI_VERSION=$(curl -fsSL https://pypi.org/pypi/synth-ai/json | jq -r '.info.version // empty')
-          if [ -z "$PYPI_VERSION" ]; then PYPI_VERSION="0.0.0"; fi
-          echo "version=$PYPI_VERSION" >> $GITHUB_OUTPUT
-          echo "PyPI version: $PYPI_VERSION"
-
       - name: Check if publish needed
         id: check
         run: |
           LOCAL="${{ steps.local.outputs.version }}"
-          PYPI="${{ steps.pypi.outputs.version }}"
-          if [ "$LOCAL" != "$PYPI" ]; then
-            echo "needs_publish=true" >> $GITHUB_OUTPUT
-            echo "Version mismatch: local=$LOCAL, pypi=$PYPI - will publish"
-          else
+          # Publish when the EXACT local version is not yet on PyPI. Comparing
+          # against .info.version (the latest STABLE) would re-fire on every dev
+          # push because a .dev prerelease never becomes .info.version, so the
+          # same prerelease would be rebuilt/republished repeatedly. Checking
+          # .releases[$LOCAL] is correct for both stable and .dev versions.
+          if curl -fsSL https://pypi.org/pypi/synth-ai/json \
+               | jq -e --arg v "$LOCAL" '.releases | has($v)' >/dev/null 2>&1; then
             echo "needs_publish=false" >> $GITHUB_OUTPUT
-            echo "Versions match: $LOCAL - skipping publish"
+            echo "Version $LOCAL already on PyPI - skipping publish"
+          else
+            echo "needs_publish=true" >> $GITHUB_OUTPUT
+            echo "Version $LOCAL not on PyPI - will publish"
           fi
 
   build-distributions:
@@ -94,6 +93,8 @@ jobs:
 
       - name: Publish to PyPI (trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   create-release:
     needs: [check-version, publish]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the `synth-ai` package are documented here.
 
 ## Unreleased
 
+## 0.15.3.dev0 — 2026-07-17
+
+Prerelease. Install with `pip install --pre synth-ai` or pin
+`synth-ai==0.15.3.dev0`.
+
+### Security
+
+- **`repr(ManagedResearchClient)` no longer leaks the API key.** `api_key` was a
+  plain dataclass field that `__post_init__` overwrites with the resolved secret,
+  so the default `repr` / `%r` / traceback frame rendered the live credential
+  (also reachable via `SynthClient().research.session`). The field is now
+  `repr=False` with an explicit redacting `__repr__` (`api_key=<set|unset>`).
+
+### Fixed
+
+- **MCP denial parity across all tools.** Typed `SmrApiError` denials were mapped
+  to structured RPC errors for only the run-launch handlers; every other tool
+  flattened to a generic `-32000` text error, dropping `error_code` /
+  `http_status` / `detail`. A central mapping now surfaces the structured
+  `-32010` payload for any tool, so SDK and MCP expose the same denial contract.
+
 ## 0.15.2 — 2026-07-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.15.2"
+version = "0.15.3.dev0"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.15.2"
+version = "0.15.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

The SDK fixes from #284 (repr API-key leak; MCP denial parity) are on `dev` but not in any published wheel — the live `0.15.2` still leaks the repr key. This lets us ship them as an **installable `.dev` prerelease from `dev`**, ahead of the next stable promotion, so the launch SDK/MCP proofs can run against a wheel that actually has the fix.

## Changes

- **`publish-dev.yml` also triggers on push to `dev`.** `main` keeps publishing stable; `dev` now publishes `.dev` prereleases to PyPI via the same trusted publisher.
- **Publish gate rewritten to check exact-version existence** (`.releases | has($v)`) instead of comparing to the latest stable (`.info.version`). A `.dev` prerelease never becomes `.info.version`, so the old check would rebuild/republish the same prerelease on every dev push. The new check is correct for both stable and `.dev`.
- **`skip-existing: true`** on the publish step as a no-op safety net for an unchanged version.
- **Bump `0.15.2` → `0.15.3.dev0`** (`pyproject.toml` + `uv.lock`), with a CHANGELOG entry. The `.dev` marker drives the prerelease path in both this workflow and the README-version CI check (which skips the badge match for dev versions).

## Verified locally

- `synth_ai.__version__ == 0.15.3.dev0`; `python -m build` produces `synth_ai-0.15.3.dev0-py3-none-any.whl` + sdist cleanly.
- `publish-dev.yml` parses as valid YAML.

## Result once merged

Merging to `dev` pushes the branch → the workflow (with the new `dev` trigger) runs against the merge commit → builds and publishes `0.15.3.dev0` to PyPI as a prerelease, and cuts a prerelease GitHub Release. Install with `pip install --pre synth-ai` or `synth-ai==0.15.3.dev0`.

## Risk to confirm

PyPI trusted publishing binds to (repo, workflow file, environment). If the `synth-laboratories/synth-ai` publisher is **ref-pinned to `main`**, the publish job will fail auth when triggered from `dev` — in that case the trusted-publisher config needs `dev` (or no ref pin) added on PyPI. `0.15.2` published fine from `main` via this same workflow/environment, so the workflow itself is proven; only the ref pin is unverified from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)