### PR TITLE
feat(research): wire research.factories.results public namespace

### DIFF
--- a/synth_ai/managed_research/models/factories.py
+++ b/synth_ai/managed_research/models/factories.py
@@ -1825,6 +1825,8 @@ class FactoryStatus:
     experiment_observability: ExperimentBundle | None = None
     judgment_state: dict[str, object] = field(default_factory=dict)
     operating_window: FactoryOperatingWindow | None = None
+    results: tuple[FactoryResult, ...] = ()
+    current_best: FactoryResult | None = None
     raw: dict[str, object] = field(default_factory=dict)
 
     @property
@@ -1922,6 +1924,14 @@ class FactoryStatus:
             operating_window=(
                 FactoryOperatingWindow.from_wire(mapping.get("operating_window"))
                 if mapping.get("operating_window") is not None
+                else None
+            ),
+            results=tuple(
+                FactoryResult.from_wire(item) for item in list(mapping.get("results") or [])
+            ),
+            current_best=(
+                FactoryResult.from_wire(mapping.get("current_best"))
+                if mapping.get("current_best") is not None
                 else None
             ),
             raw=dict(mapping),

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -42148,6 +42148,15 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SmrFactoryOperatingWindowResponse'
           - type: 'null'
+        results:
+          items:
+            $ref: '#/components/schemas/SmrFactoryResultResponse'
+          type: array
+          title: Results
+        current_best:
+          anyOf:
+          - $ref: '#/components/schemas/SmrFactoryResultResponse'
+          - type: 'null'
       type: object
       required:
       - factory
@@ -47084,7 +47093,7 @@ components:
           title: Preview Formula Version
         enforcement_status:
           type: string
-          const: not_implemented
+          const: implemented
           title: Enforcement Status
         customer_discount_percent:
           type: integer

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -14,6 +14,9 @@ from synth_ai.managed_research.models.factories import (
     FactoryChampionEvent,
     FactoryChampionRollbackRequest,
     FactoryChampionSelectRequest,
+    FactoryResult,
+    FactoryResultSelectionDecision,
+    FactoryResultSelectionEvent,
     FactoryStatus,
     FactoryWakeDueResult,
 )
@@ -273,6 +276,123 @@ class ResearchFactoryChampionsAPI:
         return tuple(self._session.factories.list_champion_events(factory_id, limit=limit))
 
 
+class ResearchFactoryResultsAPI:
+    """Factory Results — the public objects a Factory produces.
+
+    A Result is anything directly valuable a Factory produces: a report,
+    prompt, policy, dataset, model, artifact, or draft code change. Evaluation
+    and current-best selection are optional; ordinary Results carry neither.
+    These methods resolve to the same backend authority as the legacy
+    candidate/champion surfaces, so there is never a second source of truth.
+    """
+
+    def __init__(self, session: ManagedResearchClient) -> None:
+        self._session = session
+
+    def list(
+        self,
+        factory_id: str,
+        *,
+        effort_id: str | None = None,
+        run_id: str | None = None,
+        kind: str | None = None,
+        readiness: str | None = None,
+        evaluation_status: str | None = None,
+        current_best: bool | None = None,
+        limit: int = 100,
+    ) -> tuple[FactoryResult, ...]:
+        """List Results for a Factory, optionally filtered.
+
+        Filter by Effort, Run, kind, readiness, evaluation status, or
+        current-best state. Ordinary Results without evaluation are included.
+        """
+        return tuple(
+            self._session.factories.results.list(
+                factory_id,
+                effort_id=effort_id,
+                run_id=run_id,
+                kind=kind,
+                readiness=readiness,
+                evaluation_status=evaluation_status,
+                current_best=current_best,
+                limit=limit,
+            )
+        )
+
+    def get(self, factory_id: str, result_id: str) -> FactoryResult:
+        """Fetch one Result by its result id (the WorkProduct id)."""
+        return self._session.factories.results.get(factory_id, result_id)
+
+    def evaluate(
+        self,
+        factory_id: str,
+        result_id: str,
+        *,
+        evaluation: Mapping[str, Any] | dict[str, Any],
+    ) -> FactoryResult:
+        """Attach a benchmark-owned grading record to a Result.
+
+        Only candidate-backed Results accept evaluation; the backend stores
+        exactly what the grader proved and never grades itself.
+        """
+        return self._session.factories.results.evaluate(
+            factory_id,
+            result_id,
+            evaluation=evaluation,
+        )
+
+    def select_current_best(
+        self,
+        factory_id: str,
+        *,
+        result_id: str,
+        reason: str,
+        scope: str | None = None,
+        effort_id: str | None = None,
+    ) -> FactoryResultSelectionDecision:
+        """Select a passing Result as current best for a named objective/scope.
+
+        Idempotent and historical: it appends a selection event and never
+        deletes or rewrites the prior Result.
+        """
+        return self._session.factories.results.select_current_best(
+            factory_id,
+            result_id=result_id,
+            reason=reason,
+            scope=scope,
+            effort_id=effort_id,
+        )
+
+    def restore_current_best(
+        self,
+        factory_id: str,
+        *,
+        result_id: str,
+        reason: str,
+        scope: str | None = None,
+        effort_id: str | None = None,
+    ) -> FactoryResultSelectionDecision:
+        """Restore a prior Result as current best for a named objective/scope."""
+        return self._session.factories.results.restore_current_best(
+            factory_id,
+            result_id=result_id,
+            reason=reason,
+            scope=scope,
+            effort_id=effort_id,
+        )
+
+    def selection_events(
+        self,
+        factory_id: str,
+        *,
+        limit: int = 100,
+    ) -> tuple[FactoryResultSelectionEvent, ...]:
+        """List the append-only current-best selection history, newest first."""
+        return tuple(
+            self._session.factories.results.selection_events(factory_id, limit=limit)
+        )
+
+
 class ResearchFactoriesAPI:
     """Research Factory workflow API.
 
@@ -286,6 +406,18 @@ class ResearchFactoriesAPI:
         self._tag: ResearchFactoriesTagAPI | None = None
         self._candidates: ResearchFactoryCandidatesAPI | None = None
         self._champions: ResearchFactoryChampionsAPI | None = None
+        self._results: ResearchFactoryResultsAPI | None = None
+
+    @property
+    def results(self) -> ResearchFactoryResultsAPI:
+        """Factory Results — the public objects a Factory produces.
+
+        The hero surface: ``research.factories.results.list(factory_id)``.
+        Evaluation and current-best selection are optional metadata.
+        """
+        if self._results is None:
+            self._results = ResearchFactoryResultsAPI(self._session)
+        return self._results
 
     @property
     def candidates(self) -> ResearchFactoryCandidatesAPI:

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -388,9 +388,7 @@ class ResearchFactoryResultsAPI:
         limit: int = 100,
     ) -> tuple[FactoryResultSelectionEvent, ...]:
         """List the append-only current-best selection history, newest first."""
-        return tuple(
-            self._session.factories.results.selection_events(factory_id, limit=limit)
-        )
+        return tuple(self._session.factories.results.selection_events(factory_id, limit=limit))
 
 
 class ResearchFactoriesAPI:

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -381,7 +381,7 @@ class ResearchFactoryResultsAPI:
             effort_id=effort_id,
         )
 
-    def selection_events(
+    def list_selection_events(
         self,
         factory_id: str,
         *,


### PR DESCRIPTION
Exposes the hero Result surface on the **public** research client (`SynthClient().research.factories.results`), which previously only had candidates/champions. `ResearchFactoryResultsAPI` delegates to the `managed_research` `factories.results` authority — same backend, no second source of truth. Required for the docs SDK-reference generator and the Banking77/quickstart examples to reference the real hero surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)