### PR TITLE
fix(managed-research): serialize execution targets

### DIFF
--- a/synth_ai/managed_research/models/run_launch.py
+++ b/synth_ai/managed_research/models/run_launch.py
@@ -209,6 +209,7 @@ class RunLaunchRequest(CommandRequest):
     runbook_config_id: str | None = None
     local_execution: WireMapping | None = None
     execution_profile: LocalExecutionProfile | WireMapping | None = None
+    execution_target: WireMapping | None = None
     timebox_seconds: int | None = None
     agent_profile: str | None = None
     agent_model: SmrAgentModel | str | None = None
@@ -277,6 +278,7 @@ class RunLaunchRequest(CommandRequest):
             runbook_config_id=self.runbook_config_id,
             local_execution=self.local_execution,
             execution_profile=self.execution_profile,
+            execution_target=self.execution_target,
             timebox_seconds=self.timebox_seconds,
             agent_profile=self.agent_profile,
             agent_model=self.agent_model,
@@ -1224,6 +1226,7 @@ def _validate_launch_sequences(request: RunLaunchRequest) -> None:
 def _validate_launch_mappings(request: RunLaunchRequest) -> None:
     mapping_fields = (
         "local_execution",
+        "execution_target",
         "agent_model_params",
         "workflow",
         "primary_parent_ref",
@@ -1245,6 +1248,23 @@ def _validate_launch_mappings(request: RunLaunchRequest) -> None:
 
 
 def _validate_launch_combinations(request: RunLaunchRequest) -> None:
+    if request.execution_target is not None:
+        duplicated_authority = [
+            field_name
+            for field_name in (
+                "host_kind",
+                "worker_pool_id",
+                "local_execution",
+                "execution_profile",
+                "dev_environment_id",
+            )
+            if getattr(request, field_name) is not None
+        ]
+        if duplicated_authority:
+            raise ValueError(
+                "execution_target cannot be combined with legacy placement fields: "
+                + ", ".join(duplicated_authority)
+            )
     if (
         request.work_mode is not None
         and request.mode is not None
@@ -1280,7 +1300,7 @@ def _validate_launch_combinations(request: RunLaunchRequest) -> None:
         )
     if _requires_explicit_launch_axes(request):
         missing = []
-        if request.host_kind is None:
+        if request.host_kind is None and request.execution_target is None:
             missing.append("host_kind")
         if request.work_mode is None and request.mode is None:
             missing.append("work_mode")

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -640,6 +640,7 @@ def _build_project_run_payload(
     runbook_config_id: str | None = None,
     local_execution: Mapping[str, Any] | dict[str, Any] | None = None,
     execution_profile: LocalExecutionProfile | Mapping[str, Any] | dict[str, Any] | None = None,
+    execution_target: Mapping[str, Any] | dict[str, Any] | None = None,
     timebox_seconds: int | None = None,
     agent_profile: str | None = None,
     agent_model: SmrAgentModel | str | None = None,
@@ -674,6 +675,32 @@ def _build_project_run_payload(
     idempotency_key_run_create: str | None = None,
     idempotency_key: str | None = None,
 ) -> dict[str, Any]:
+    normalized_execution_target = _optional_mapping(
+        execution_target,
+        field_name="execution_target",
+    )
+    if normalized_execution_target:
+        target_kind = str(normalized_execution_target.get("kind") or "").strip()
+        if target_kind not in {"platform_resolved", "bound_runtime"}:
+            raise ValueError(
+                "execution_target.kind must be platform_resolved or bound_runtime"
+            )
+        duplicated_authority = [
+            field_name
+            for field_name, value in (
+                ("host_kind", host_kind),
+                ("worker_pool_id", worker_pool_id),
+                ("local_execution", local_execution),
+                ("execution_profile", execution_profile),
+                ("dev_environment_id", dev_environment_id),
+            )
+            if value is not None
+        ]
+        if duplicated_authority:
+            raise ValueError(
+                "execution_target cannot be combined with legacy placement fields: "
+                + ", ".join(duplicated_authority)
+            )
     assert_hosted_launch_surface(
         local_execution=local_execution,
         agent_model=agent_model,
@@ -695,6 +722,8 @@ def _build_project_run_payload(
         field_name="intended_horizon_hours",
     )
     payload: dict[str, Any] = {}
+    if normalized_execution_target:
+        payload["execution_target"] = normalized_execution_target
     if preset_id:
         payload["runbook_preset"] = preset_id
     if config_id:
@@ -5470,6 +5499,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         runbook_config_id: str | None = None,
         local_execution: Mapping[str, Any] | dict[str, Any] | None = None,
         execution_profile: LocalExecutionProfile | Mapping[str, Any] | dict[str, Any] | None = None,
+        execution_target: Mapping[str, Any] | dict[str, Any] | None = None,
         timebox_seconds: int | None = None,
         agent_profile: str | None = None,
         agent_model: SmrAgentModel | str | None = None,
@@ -5520,6 +5550,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
             runbook_config_id=runbook_config_id,
             local_execution=local_execution,
             execution_profile=execution_profile,
+            execution_target=execution_target,
             timebox_seconds=timebox_seconds,
             agent_profile=agent_profile,
             agent_model=agent_model,
@@ -5623,6 +5654,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         runbook_config_id: str | None = None,
         local_execution: Mapping[str, Any] | dict[str, Any] | None = None,
         execution_profile: LocalExecutionProfile | Mapping[str, Any] | dict[str, Any] | None = None,
+        execution_target: Mapping[str, Any] | dict[str, Any] | None = None,
         timebox_seconds: int | None = None,
         agent_profile: str | None = None,
         agent_model: SmrAgentModel | str | None = None,
@@ -5689,6 +5721,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
             runbook_config_id=runbook_config_id,
             local_execution=local_execution,
             execution_profile=execution_profile,
+            execution_target=execution_target,
             timebox_seconds=timebox_seconds,
             agent_profile=agent_profile,
             agent_model=agent_model,


### PR DESCRIPTION
Adds the typed execution_target launch field to the synth-ai Managed Research boundary, carries it through preflight and trigger payloads, and rejects mixed target plus legacy placement authority. Validation: py_compile, diff check, and direct payload probe. Ruff, ty, and automated tests were not run.