### PR TITLE
fix(research): decode artifact content envelope in run readouts

### DIFF
--- a/synth_ai/research/run_readouts.py
+++ b/synth_ai/research/run_readouts.py
@@ -602,9 +602,20 @@ class ResearchRunArtifactsContentAPI(_RunReadoutBound):
             artifact_id: Artifact identifier from ``list`` or the manifest.
             as_text: When ``True``, decode as UTF-8 text; otherwise return bytes.
         """
-        return self._handle._client.get_artifact_content(
-            artifact_id,
-            as_text=as_text,
+        payload = self._handle._client.get_artifact_content(artifact_id)
+        encoding = str(payload.get("encoding") or "utf-8")
+        content = payload["content"]
+        if encoding == "base64":
+            import base64
+
+            raw = base64.b64decode(str(content))
+            return raw.decode("utf-8") if as_text else raw
+        if encoding == "utf-8":
+            text = str(content)
+            return text if as_text else text.encode("utf-8")
+        raise ValueError(
+            f"artifact {artifact_id} content has unsupported encoding {encoding!r}; "
+            "expected 'utf-8' or 'base64'"
         )
 
 

--- a/tests/research/test_run_readouts_content.py
+++ b/tests/research/test_run_readouts_content.py
@@ -1,0 +1,74 @@
+"""Tests for run-readout content adapters against a stubbed client (no network)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from synth_ai.research.run_readouts import (
+    ResearchRunArtifactsContentAPI,
+    ResearchRunWorkProductsContentAPI,
+)
+
+
+class _StubWorkProductsAPI:
+    def content(self, work_product_id: str, *, as_text: bool = True) -> str | bytes:
+        raw = b"work product body"
+        return raw.decode("utf-8") if as_text else raw
+
+
+class _StubClient:
+    def __init__(self, envelope: dict[str, object]) -> None:
+        self.envelope = envelope
+        self.calls: list[str] = []
+        self.work_products = _StubWorkProductsAPI()
+
+    def get_artifact_content(self, artifact_id: str, *, disposition: str = "inline") -> dict:
+        self.calls.append(artifact_id)
+        return dict(self.envelope)
+
+
+class _StubHandle:
+    def __init__(self, client: _StubClient) -> None:
+        self._client = client
+        self.run_id = "run_test"
+        self.project_id = "proj_test"
+
+
+def _artifacts_api(envelope: dict[str, object]) -> ResearchRunArtifactsContentAPI:
+    return ResearchRunArtifactsContentAPI(_StubHandle(_StubClient(envelope)))
+
+
+def test_artifact_content_utf8_as_text() -> None:
+    api = _artifacts_api({"content": "hello", "encoding": "utf-8"})
+    assert api.get("art_1") == "hello"
+
+
+def test_artifact_content_utf8_as_bytes() -> None:
+    api = _artifacts_api({"content": "hello", "encoding": "utf-8"})
+    assert api.get("art_1", as_text=False) == b"hello"
+
+
+def test_artifact_content_base64_as_text() -> None:
+    encoded = base64.b64encode(b"payload").decode("ascii")
+    api = _artifacts_api({"content": encoded, "encoding": "base64"})
+    assert api.get("art_1") == "payload"
+
+
+def test_artifact_content_base64_as_bytes() -> None:
+    encoded = base64.b64encode(b"\x00\x01binary").decode("ascii")
+    api = _artifacts_api({"content": encoded, "encoding": "base64"})
+    assert api.get("art_1", as_text=False) == b"\x00\x01binary"
+
+
+def test_artifact_content_unknown_encoding_raises() -> None:
+    api = _artifacts_api({"content": "x", "encoding": "zstd"})
+    with pytest.raises(ValueError, match="unsupported encoding 'zstd'"):
+        api.get("art_1")
+
+
+def test_work_products_content_passthrough() -> None:
+    handle = _StubHandle(_StubClient({}))
+    api = ResearchRunWorkProductsContentAPI(handle)
+    assert api.get("wp_1") == "work product body"
+    assert api.get("wp_1", as_text=False) == b"work product body"


### PR DESCRIPTION
## Defect

`ResearchRunArtifactsContentAPI.get(artifact_id, *, as_text=True)` in `synth_ai/research/run_readouts.py` called `ManagedResearchClient.get_artifact_content(artifact_id, as_text=as_text)`, but the client method signature is `(self, artifact_id, *, disposition="inline") -> dict`. Every call raised `TypeError: unexpected keyword argument 'as_text'` — and even with the keyword removed, the client returns a content-envelope dict where the adapter promises `str | bytes`. This broke artifact retrieval in a live campaign (run 88d0bbe8, artifact 0a0457bc).

## Envelope shape (verified)

The backend route (`GET /smr/artifacts/{artifact_id}/content`) serves raw bytes (or a 302 to a presigned S3 URL); the SDK's `_request_content` wraps the response into:

```json
{"content": "<utf-8 text or base64>", "encoding": "utf-8" | "base64", "content_type": "...", "content_bytes": 123}
```

## Fix

- Call `get_artifact_content(artifact_id)` with its real signature and decode the envelope per its declared encoding — `base64` → raw bytes (utf-8 decoded when `as_text=True`), `utf-8` → text (encoded when `as_text=False`), mirroring the existing hosted-artifact decode path in the same file. Unknown encoding raises a `ValueError` naming the encoding — no fallback ladder.
- Audited sibling `ResearchRunWorkProductsContentAPI.get`: `client.work_products.content(work_product_id, as_text=...)` exists (`WorkProductsAPI.content` → `get_run_work_product_content`) with matching signature and `str | bytes` return — not broken, unchanged.

## Tests

`tests/research/test_run_readouts_content.py` — stubbed client, no network: as_text True/False × utf-8/base64, unknown-encoding rejection, work-products passthrough. `uv run --with pytest pytest` → 6 passed; ruff clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)