### PR TITLE
feat(research): add candidate output kind and actor-binding divergence anomaly

### DIFF
--- a/synth_ai/managed_research/models/run_launch.py
+++ b/synth_ai/managed_research/models/run_launch.py
@@ -441,6 +441,7 @@ class RunSnapshot:
 class OutputKind(StrEnum):
     REPORT = "report"
     MODEL = "model"
+    CANDIDATE = "candidate"
     TRAINED_MODEL = "trained_model"
     CONTAINER_EVAL = "container_eval"
     CONTAINER_EVALUATION = "container_evaluation"

--- a/synth_ai/managed_research/models/run_observability.py
+++ b/synth_ai/managed_research/models/run_observability.py
@@ -158,6 +158,7 @@ class RunAnomalyKind(StrEnum):
     RUN_TERMINAL_WITH_PENDING_RUNTIME_INTENTS = "run_terminal_with_pending_runtime_intents"
     MCP_UNREACHABLE = "mcp_unreachable"
     TERMINAL_WITHOUT_PUBLICATION_VERDICT = "terminal_without_publication_verdict"
+    ACTOR_BINDING_PROJECTION_DIVERGENCE = "actor_binding_projection_divergence"
 
 
 @dataclass(frozen=True)

--- a/synth_ai/managed_research/models/types.py
+++ b/synth_ai/managed_research/models/types.py
@@ -309,10 +309,10 @@ class RequiredWorkProductSpec:
             "kind",
             label="kickoff contract required_work_product.kind",
         )
-        if kind not in {"report", "model", "container_eval"}:
+        if kind not in {"report", "model", "candidate", "container_eval"}:
             raise ValueError(
                 "kickoff contract required_work_product.kind must be one of "
-                "report, model, container_eval"
+                "report, model, candidate, container_eval"
             )
         required_value = mapping.get("required", True)
         if not isinstance(required_value, bool):

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -682,9 +682,7 @@ def _build_project_run_payload(
     if normalized_execution_target:
         target_kind = str(normalized_execution_target.get("kind") or "").strip()
         if target_kind not in {"platform_resolved", "bound_runtime"}:
-            raise ValueError(
-                "execution_target.kind must be platform_resolved or bound_runtime"
-            )
+            raise ValueError("execution_target.kind must be platform_resolved or bound_runtime")
         duplicated_authority = [
             field_name
             for field_name, value in (


### PR DESCRIPTION
Lands the 3-file diff preserved on `rescue/research-factories-results-dirty-20260719` (rescue commit `6c39acff`), pairing with the backend candidate WorkProduct publication PR.

- Add `CANDIDATE = "candidate"` to `OutputKind` in `synth_ai/managed_research/models/run_launch.py`
- Add `ACTOR_BINDING_PROJECTION_DIVERGENCE` to `RunAnomalyKind` in `synth_ai/managed_research/models/run_observability.py`
- Accept "candidate" in `RequiredWorkProductSpec` allowed kinds in `synth_ai/managed_research/models/types.py` (and update the error message)

Validation: `uv run ruff check` on the 3 files passes; the 3 modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)