### PR TITLE
fix(managed_research): forward-compatible run anomaly kinds (B11)

### DIFF
--- a/synth_ai/managed_research/models/run_observability.py
+++ b/synth_ai/managed_research/models/run_observability.py
@@ -158,6 +158,9 @@ class RunAnomalyKind(StrEnum):
     RUN_TERMINAL_WITH_PENDING_RUNTIME_INTENTS = "run_terminal_with_pending_runtime_intents"
     MCP_UNREACHABLE = "mcp_unreachable"
     TERMINAL_WITHOUT_PUBLICATION_VERDICT = "terminal_without_publication_verdict"
+    ACTOR_BINDING_PROJECTION_DIVERGENCE = "actor_binding_projection_divergence"
+    UNKNOWN = "unknown"
+    """Forward-compat marker: wire kind not in this pinned enum; see RunAnomaly.raw_kind."""
 
 
 @dataclass(frozen=True)
@@ -827,13 +830,31 @@ class RunTickingUpdate:
 class RunAnomaly:
     kind: RunAnomalyKind
     detail: str
+    raw_kind: str = ""
+    """Exact wire value of ``kind``. For known kinds this equals ``kind.value``;
+    when ``kind`` is ``RunAnomalyKind.UNKNOWN`` it carries the unrecognized wire string."""
+
+    def __post_init__(self) -> None:
+        if not self.raw_kind:
+            object.__setattr__(self, "raw_kind", self.kind.value)
+
+    @property
+    def is_unknown_kind(self) -> bool:
+        """True when the backend emitted an anomaly kind this SDK does not know."""
+        return self.kind is RunAnomalyKind.UNKNOWN and self.raw_kind != RunAnomalyKind.UNKNOWN.value
 
     @classmethod
     def from_wire(cls, payload: object) -> RunAnomaly:
         mapping = _require_mapping(payload, label="run anomaly")
+        raw_kind = _require_string(mapping, "kind", label="anomaly.kind")
+        try:
+            kind = RunAnomalyKind(raw_kind)
+        except ValueError:
+            kind = RunAnomalyKind.UNKNOWN
         return cls(
-            kind=RunAnomalyKind(_require_string(mapping, "kind", label="anomaly.kind")),
+            kind=kind,
             detail=_require_string(mapping, "detail", label="anomaly.detail"),
+            raw_kind=raw_kind,
         )
 
 

--- a/tests/managed_research/test_run_anomaly_forward_compat.py
+++ b/tests/managed_research/test_run_anomaly_forward_compat.py
@@ -1,0 +1,99 @@
+"""Forward-compat parsing of run anomalies: unknown wire kinds must not kill polling."""
+
+from __future__ import annotations
+
+from synth_ai.managed_research.models.run_observability import (
+    RunAnomaly,
+    RunAnomalyKind,
+    RunObservabilitySnapshot,
+)
+
+
+def _snapshot_payload(anomalies: list[dict[str, object]]) -> dict[str, object]:
+    """Minimal valid run observability snapshot wire payload."""
+    return {
+        "schema_version": "run_observability.v1",
+        "project_id": "proj_x",
+        "run_id": "run_x",
+        "generated_at": "2026-07-20T00:00:00Z",
+        "run": {"project_id": "proj_x", "run_id": "run_x", "public_state": "running"},
+        "lifecycle": {
+            "authority_phase": "executing",
+            "terminal_phase": "none",
+            "dispatch": {"owner": "backend", "pool_id": "pool_x", "host_kind": "hosted"},
+        },
+        "public_state": "running",
+        "run_contract": {
+            "schema_version": "run_contract.v1",
+            "project_id": "proj_x",
+            "run_id": "run_x",
+            "public_state": "running",
+            "terminal": False,
+            "lifecycle": {"phase": "executing"},
+            "finalization": {"status": "pending"},
+            "recovery": {"status": "idle"},
+            "tasks": {"total": 1, "terminal": 0, "nonterminal": 1},
+            "artifacts": {"readiness": "pending"},
+            "execution_route": {"route": "hosted"},
+            "work_products": {},
+            "trained_models": {},
+            "container_eval_packages": {},
+            "incidents": {"unresolved": 0},
+            "diagnostics": {},
+        },
+        "candidate_publication": {"outcome": "running"},
+        "actors": {},
+        "tasks": {},
+        "runtime": {},
+        "cursor": {},
+        "anomalies": anomalies,
+    }
+
+
+def test_known_kind_parses_to_member() -> None:
+    anomaly = RunAnomaly.from_wire(
+        {"kind": "mcp_unreachable", "detail": "runtime MCP endpoint refused connection"}
+    )
+    assert anomaly.kind is RunAnomalyKind.MCP_UNREACHABLE
+    assert anomaly.raw_kind == "mcp_unreachable"
+    assert anomaly.detail == "runtime MCP endpoint refused connection"
+    assert not anomaly.is_unknown_kind
+
+
+def test_actor_binding_projection_divergence_is_known() -> None:
+    anomaly = RunAnomaly.from_wire(
+        {"kind": "actor_binding_projection_divergence", "detail": "projection diverged"}
+    )
+    assert anomaly.kind is RunAnomalyKind.ACTOR_BINDING_PROJECTION_DIVERGENCE
+    assert not anomaly.is_unknown_kind
+
+
+def test_unknown_kind_parses_and_preserves_raw_value_and_detail() -> None:
+    anomaly = RunAnomaly.from_wire(
+        {
+            "kind": "quantum_flux_capacitor_drift",
+            "detail": "synthetic future anomaly emitted by a newer backend",
+        }
+    )
+    assert anomaly.kind is RunAnomalyKind.UNKNOWN
+    assert anomaly.raw_kind == "quantum_flux_capacitor_drift"
+    assert anomaly.detail == "synthetic future anomaly emitted by a newer backend"
+    assert anomaly.is_unknown_kind
+
+
+def test_snapshot_with_new_anomaly_string_parses_end_to_end() -> None:
+    snapshot = RunObservabilitySnapshot.from_wire(
+        _snapshot_payload(
+            [
+                {"kind": "actor_binding_projection_divergence", "detail": "known kind"},
+                {"kind": "quantum_flux_capacitor_drift", "detail": "future kind"},
+            ]
+        )
+    )
+    known, unknown = snapshot.anomalies
+    assert known.kind is RunAnomalyKind.ACTOR_BINDING_PROJECTION_DIVERGENCE
+    assert not known.is_unknown_kind
+    assert unknown.kind is RunAnomalyKind.UNKNOWN
+    assert unknown.raw_kind == "quantum_flux_capacitor_drift"
+    assert unknown.detail == "future kind"
+    assert unknown.is_unknown_kind


### PR DESCRIPTION
## Defect (B11, LLM-MARL contract-gaps handoff)

The backend emitted anomaly kind `actor_binding_projection_divergence`; the pinned `RunAnomalyKind` enum in `synth_ai/managed_research/models/run_observability.py` rejected it, so `RunAnomaly.from_wire` raised `ValueError` inside `RunObservabilitySnapshot.from_wire` and killed Factory-controller polling while the run continued.

## Design

1. **Enum member added**: `ACTOR_BINDING_PROJECTION_DIVERGENCE = "actor_binding_projection_divergence"` — matches the intent of in-flight work so the diffs converge.
2. **Forward compatibility** (the durable part — a reactive enum-add alone just waits for the next unknown kind):
   - New `RunAnomalyKind.UNKNOWN` marker member.
   - `RunAnomaly` gains `raw_kind: str` — always the exact wire string (`__post_init__` fills it from `kind.value` for direct constructions), plus an `is_unknown_kind` property.
   - `RunAnomaly.from_wire` maps an unrecognized wire kind to `UNKNOWN` while preserving the raw string and the `detail` payload. Parsing never raises for unknown kinds; nothing is dropped — controllers see the raw value and can decide continue/stop.

## Overlap notice

This intentionally overlaps uncommitted in-flight work in the canonical checkout that adds the same enum member to `run_observability.py`. Whoever holds that WIP should rebase on this branch — the member value here is identical, and this PR additionally carries the forward-compat machinery both handoffs agreed is required.

## Tests

`tests/managed_research/test_run_anomaly_forward_compat.py` — parses a full minimal `RunObservabilitySnapshot` wire payload containing a synthetic future anomaly string (`quantum_flux_capacitor_drift`) alongside a known kind: parsing succeeds, raw value and detail retained, known kinds still bind to their members. `uv run --with pytest pytest` → 4 passed; ruff clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)