### PR TITLE
feat(managed-research): typed scientific-integrity models for backend PR #734

### DIFF
--- a/synth_ai/managed_research/mcp/tools/projects.py
+++ b/synth_ai/managed_research/mcp/tools/projects.py
@@ -450,7 +450,11 @@ def build_project_tools(server: Any) -> list[ToolDefinition]:
                 "Attach a normalized measured result to an SMR experiment. "
                 "Use one result row per candidate metric/split. Observable Factory "
                 "experiments include experiment_registration, synth_wiki_changeset, "
-                "git_server_receipt, and budget_receipt inside metadata."
+                "git_server_receipt, and budget_receipt inside metadata. Requires "
+                "evaluation_mode (live|mock|fixture|offline_fallback; non-live rows "
+                "are non-scientific smoke) and an intervention_receipt.v1 whose "
+                "declared fields are present in both the transmitted request and "
+                "runtime-effective readback."
             ),
             input_schema=tool_schema(
                 {
@@ -478,10 +482,52 @@ def build_project_tools(server: Any) -> list[ToolDefinition]:
                     "per_example_artifact_path": {"type": "string"},
                     "evidence_grade": {"type": "string"},
                     "truth_status": {"type": "string"},
+                    "evaluation_mode": {
+                        "type": "string",
+                        "enum": [
+                            "live",
+                            "mock",
+                            "fixture",
+                            "offline_fallback",
+                        ],
+                    },
+                    "intervention_receipt": {
+                        "type": "object",
+                        "properties": {
+                            "schema_version": {
+                                "type": "string",
+                                "const": "intervention_receipt.v1",
+                            },
+                            "declared_changed_fields": {"type": "object"},
+                            "transmitted_request_fields": {"type": "object"},
+                            "runtime_effective_config": {"type": "object"},
+                            "held_constant_fields": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "unexpected_differences": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                        "required": [
+                            "schema_version",
+                            "declared_changed_fields",
+                            "transmitted_request_fields",
+                            "runtime_effective_config",
+                        ],
+                    },
                     "caveats": {"type": "string"},
                     "metadata": {"type": "object"},
                 },
-                required=["project_id", "experiment_id", "metric", "value"],
+                required=[
+                    "project_id",
+                    "experiment_id",
+                    "metric",
+                    "value",
+                    "evaluation_mode",
+                    "intervention_receipt",
+                ],
             ),
             handler=server._tool_attach_project_experiment_result,
         ),

--- a/synth_ai/managed_research/models/__init__.py
+++ b/synth_ai/managed_research/models/__init__.py
@@ -406,6 +406,18 @@ from synth_ai.managed_research.models.runtime_intent import (
     RuntimeIntentView,
     RuntimeMessageMode,
 )
+from synth_ai.managed_research.models.scientific_integrity import (
+    INTERVENTION_RECEIPT_SCHEMA_VERSION,
+    InterventionReceiptV1,
+    SmrEvaluationMode,
+    SmrScientificStatus,
+    compile_intervention_receipt,
+    grading_record_evaluation_mode,
+    parse_evaluation_mode,
+    parse_intervention_receipt,
+    scientific_status_for_mode,
+    verify_intervention_receipt,
+)
 from synth_ai.managed_research.models.smr_actor_models import (
     SmrActorModelAssignment,
     SmrActorSubtype,
@@ -1025,4 +1037,14 @@ __all__ = [
     "TranscriptCoverageEvidence",
     "assemble_factory_evidence_packet",
     "assemble_factory_launch_readiness",
+    "INTERVENTION_RECEIPT_SCHEMA_VERSION",
+    "InterventionReceiptV1",
+    "SmrEvaluationMode",
+    "SmrScientificStatus",
+    "compile_intervention_receipt",
+    "grading_record_evaluation_mode",
+    "parse_evaluation_mode",
+    "parse_intervention_receipt",
+    "scientific_status_for_mode",
+    "verify_intervention_receipt",
 ]

--- a/synth_ai/managed_research/models/factories.py
+++ b/synth_ai/managed_research/models/factories.py
@@ -17,6 +17,10 @@ from synth_ai.managed_research.models.run_state import (
     _require_mapping,
     _require_string,
 )
+from synth_ai.managed_research.models.scientific_integrity import (
+    SmrEvaluationMode,
+    grading_record_evaluation_mode,
+)
 
 
 class FactoryKind(StrEnum):
@@ -2114,9 +2118,30 @@ class FactoryWakeDueResult:
 
 @dataclass(frozen=True)
 class FactoryCandidateGradingRequest:
-    """Benchmark-owned grading record submitted for one immutable candidate."""
+    """Benchmark-owned grading record submitted for one immutable candidate.
+
+    Mirrors the backend's scientific-integrity contract
+    (``services/smr/factory_candidates.py::validate_candidate_grading_record``,
+    ``services/smr/science/integrity.py``): a ``status: "graded"`` record must
+    declare ``evaluation_mode``. Validating here fails fast with the same
+    typed error class the backend would otherwise return after a round trip.
+    """
 
     grading: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if str(self.grading.get("status") or "").strip().lower() != "graded":
+            return
+        try:
+            mode = grading_record_evaluation_mode(self.grading)
+        except ValueError as exc:
+            raise ValueError(f"grading_evaluation_mode_invalid: {exc}") from None
+        if mode is None:
+            raise ValueError(
+                "grading_evaluation_mode_missing: status 'graded' requires "
+                "evaluation_mode (one of "
+                f"{sorted(m.value for m in SmrEvaluationMode)})"
+            )
 
     def to_wire(self) -> dict[str, Any]:
         return {"grading": dict(self.grading)}
@@ -2646,6 +2671,12 @@ def factory_candidate_grading_payload(
 ) -> dict[str, Any]:
     if isinstance(request, FactoryCandidateGradingRequest):
         return request.to_wire()
+    # Route raw mappings through the typed constructor too, so the
+    # scientific-integrity evaluation_mode check runs regardless of whether
+    # the caller passed a typed request or a plain ``{"grading": {...}}`` dict.
+    grading = dict(request).get("grading")
+    if isinstance(grading, Mapping):
+        return FactoryCandidateGradingRequest(grading=dict(grading)).to_wire()
     return dict(request)
 
 

--- a/synth_ai/managed_research/models/scientific_integrity.py
+++ b/synth_ai/managed_research/models/scientific_integrity.py
@@ -1,0 +1,233 @@
+"""Scientific-integrity contracts mirrored from the backend authority.
+
+Mirrors ``services/smr/science/integrity.py`` in ``backend`` (PR #734,
+``feat/scientific-verdicts-intervention-gate``). The backend gate at
+``smr_attach_experiment_result`` and the Factory candidate-grading intake
+(``validate_candidate_grading_record``) both require a typed
+``evaluation_mode`` and, for experiment-result attachment, a verified
+``intervention_receipt.v1``. These client-side mirrors let SDK callers build
+and validate the same payloads before submission and fail with the same
+stable failure-class tokens the backend uses, rather than discovering a
+rejection only after a round trip.
+
+Every rejection raises ``ValueError`` whose message begins with a stable
+failure class token (``evaluation_mode_missing``, ``evaluation_mode_invalid``,
+``intervention_receipt_missing``, ``intervention_receipt_invalid``,
+``intervention_receipt_schema_unsupported``,
+``intervention_receipt_declared_field_not_transmitted``,
+``intervention_receipt_declared_field_not_read_back``,
+``intervention_receipt_declared_field_readback_mismatch``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class SmrEvaluationMode(StrEnum):
+    """How the measured episodes were actually executed."""
+
+    LIVE = "live"
+    MOCK = "mock"
+    FIXTURE = "fixture"
+    OFFLINE_FALLBACK = "offline_fallback"
+
+
+class SmrScientificStatus(StrEnum):
+    """Scientific validity verdict — distinct from lifecycle and verifier."""
+
+    SCIENTIFIC = "scientific"
+    NON_SCIENTIFIC_SMOKE = "non_scientific_smoke"
+
+
+INTERVENTION_RECEIPT_SCHEMA_VERSION = "intervention_receipt.v1"
+
+
+def parse_evaluation_mode(value: Any) -> SmrEvaluationMode:
+    """Parse a declared evaluation mode; absent/unknown is a typed rejection."""
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise ValueError(
+            "evaluation_mode_missing: experiment-result attachment requires "
+            "evaluation_mode (one of "
+            f"{sorted(m.value for m in SmrEvaluationMode)})"
+        )
+    text = str(value).strip().lower()
+    try:
+        return SmrEvaluationMode(text)
+    except ValueError:
+        raise ValueError(
+            f"evaluation_mode_invalid: {text!r} is not one of "
+            f"{sorted(m.value for m in SmrEvaluationMode)}"
+        ) from None
+
+
+def scientific_status_for_mode(
+    mode: SmrEvaluationMode | str,
+) -> SmrScientificStatus:
+    """Only live execution can carry the scientific verdict."""
+    if str(mode) == SmrEvaluationMode.LIVE.value:
+        return SmrScientificStatus.SCIENTIFIC
+    return SmrScientificStatus.NON_SCIENTIFIC_SMOKE
+
+
+@dataclass(frozen=True)
+class InterventionReceiptV1:
+    """Versioned receipt binding declaration → transmission → readback.
+
+    ``declared_changed_fields`` maps each intervention field name to its
+    declared value. ``transmitted_request_fields`` is the exact field map
+    sent to the evaluated service. ``runtime_effective_config`` is the
+    runtime's effective-config readback after applying the request.
+    """
+
+    declared_changed_fields: dict[str, Any]
+    transmitted_request_fields: dict[str, Any]
+    runtime_effective_config: dict[str, Any]
+    held_constant_fields: tuple[str, ...] = ()
+    unexpected_differences: tuple[str, ...] = ()
+    schema_version: str = INTERVENTION_RECEIPT_SCHEMA_VERSION
+
+    def payload(self) -> dict[str, Any]:
+        """JSON-storable form of this receipt."""
+        return {
+            "schema_version": self.schema_version,
+            "declared_changed_fields": dict(self.declared_changed_fields),
+            "transmitted_request_fields": dict(self.transmitted_request_fields),
+            "runtime_effective_config": dict(self.runtime_effective_config),
+            "held_constant_fields": list(self.held_constant_fields),
+            "unexpected_differences": list(self.unexpected_differences),
+        }
+
+
+def parse_intervention_receipt(value: Any) -> InterventionReceiptV1:
+    """Parse a receipt payload; absent/malformed is a typed rejection."""
+    if value is None:
+        raise ValueError(
+            "intervention_receipt_missing: experiment-result attachment "
+            f"requires an {INTERVENTION_RECEIPT_SCHEMA_VERSION} receipt"
+        )
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            f"intervention_receipt_invalid: receipt must be a mapping, got {type(value).__name__}"
+        )
+    schema = str(value.get("schema_version") or "").strip()
+    if schema != INTERVENTION_RECEIPT_SCHEMA_VERSION:
+        raise ValueError(
+            "intervention_receipt_schema_unsupported: expected "
+            f"{INTERVENTION_RECEIPT_SCHEMA_VERSION!r}, got {schema!r}"
+        )
+    declared = value.get("declared_changed_fields")
+    transmitted = value.get("transmitted_request_fields")
+    readback = value.get("runtime_effective_config")
+    for name, part in (
+        ("declared_changed_fields", declared),
+        ("transmitted_request_fields", transmitted),
+        ("runtime_effective_config", readback),
+    ):
+        if not isinstance(part, Mapping):
+            raise ValueError(
+                f"intervention_receipt_invalid: {name} must be a mapping, got {type(part).__name__}"
+            )
+    return InterventionReceiptV1(
+        declared_changed_fields=dict(declared),
+        transmitted_request_fields=dict(transmitted),
+        runtime_effective_config=dict(readback),
+        held_constant_fields=tuple(str(item) for item in (value.get("held_constant_fields") or [])),
+        unexpected_differences=tuple(
+            str(item) for item in (value.get("unexpected_differences") or [])
+        ),
+    )
+
+
+def verify_intervention_receipt(receipt: InterventionReceiptV1) -> None:
+    """Reject when a declared field never reached the wire or the runtime.
+
+    A declared intervention field must appear in the transmitted request
+    fields AND in the runtime effective-config readback, and the readback
+    value must equal the declared value.
+    """
+    for name, declared_value in receipt.declared_changed_fields.items():
+        if name not in receipt.transmitted_request_fields:
+            raise ValueError(
+                "intervention_receipt_declared_field_not_transmitted: "
+                f"declared field {name!r} is absent from "
+                "transmitted_request_fields"
+            )
+        if name not in receipt.runtime_effective_config:
+            raise ValueError(
+                "intervention_receipt_declared_field_not_read_back: "
+                f"declared field {name!r} is absent from "
+                "runtime_effective_config"
+            )
+        readback_value = receipt.runtime_effective_config[name]
+        if readback_value != declared_value:
+            raise ValueError(
+                "intervention_receipt_declared_field_readback_mismatch: "
+                f"declared field {name!r} declared={declared_value!r} "
+                f"readback={readback_value!r}"
+            )
+
+
+def compile_intervention_receipt(
+    *,
+    declared_changed_fields: Mapping[str, Any],
+    transmitted_request_fields: Mapping[str, Any],
+    runtime_effective_config: Mapping[str, Any],
+    held_constant_fields: tuple[str, ...] = (),
+) -> InterventionReceiptV1:
+    """Build and verify a receipt in one call, deriving ``unexpected_differences``.
+
+    ``unexpected_differences`` names any ``held_constant_fields`` entry whose
+    transmitted value diverges from its runtime-effective readback — a signal
+    that something outside the declared intervention drifted between request
+    and execution. Raises the same typed ``ValueError`` as
+    :func:`verify_intervention_receipt` when a declared field failed to reach
+    the wire or the runtime.
+    """
+    unexpected_differences = tuple(
+        name
+        for name in held_constant_fields
+        if name in transmitted_request_fields
+        and name in runtime_effective_config
+        and transmitted_request_fields[name] != runtime_effective_config[name]
+    )
+    receipt = InterventionReceiptV1(
+        declared_changed_fields=dict(declared_changed_fields),
+        transmitted_request_fields=dict(transmitted_request_fields),
+        runtime_effective_config=dict(runtime_effective_config),
+        held_constant_fields=tuple(held_constant_fields),
+        unexpected_differences=unexpected_differences,
+    )
+    verify_intervention_receipt(receipt)
+    return receipt
+
+
+def grading_record_evaluation_mode(
+    record: Mapping[str, Any],
+) -> SmrEvaluationMode | None:
+    """Read the evaluation mode a grading record declares, if any.
+
+    Returns ``None`` for legacy records written before the contract; any
+    present-but-invalid value is a typed rejection.
+    """
+    raw = record.get("evaluation_mode")
+    if raw is None:
+        return None
+    return parse_evaluation_mode(raw)
+
+
+__all__ = [
+    "INTERVENTION_RECEIPT_SCHEMA_VERSION",
+    "InterventionReceiptV1",
+    "SmrEvaluationMode",
+    "SmrScientificStatus",
+    "compile_intervention_receipt",
+    "grading_record_evaluation_mode",
+    "parse_evaluation_mode",
+    "parse_intervention_receipt",
+    "scientific_status_for_mode",
+    "verify_intervention_receipt",
+]


### PR DESCRIPTION
## Summary
- Backend PR #734 (`feat/scientific-verdicts-intervention-gate`) added a required `evaluation_mode` enum and `intervention_receipt.v1` gate to `smr_attach_experiment_result` and to Factory candidate-grading intake (`validate_candidate_grading_record`).
- Adds `synth_ai/managed_research/models/scientific_integrity.py`, a client-side mirror of backend's `services/smr/science/integrity.py`: `SmrEvaluationMode`, `SmrScientificStatus`, `InterventionReceiptV1`, and the same parse/verify helpers (`parse_evaluation_mode`, `parse_intervention_receipt`, `verify_intervention_receipt`, `grading_record_evaluation_mode`), plus a `compile_intervention_receipt` convenience that derives `unexpected_differences` from a held-constant field list.
- Exports the new models from `synth_ai.managed_research.models`.
- Wires a fail-fast check into `FactoryCandidateGradingRequest` (and the raw-mapping path through `factory_candidate_grading_payload`) so a `status="graded"` grading record missing `evaluation_mode` raises the same `grading_evaluation_mode_missing`/`grading_evaluation_mode_invalid` typed error client-side, before the round trip to `services/smr/factory_candidates.py`.

## Test plan
- [x] `uv run python -c "..."` smoke: imports resolve, `compile_intervention_receipt` round-trips, `FactoryCandidateGradingRequest(grading={"status": "graded"})` raises `grading_evaluation_mode_missing`, and a `{"grading": {...}}` raw mapping with `evaluation_mode` set passes through `factory_candidate_grading_payload`.
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files.
- [ ] No new tests added per house rule (tests only when explicitly requested).

Made with [Cursor](https://cursor.com)