### PR TITLE
feat(research): core swarm ergonomics — launch_and_wait, retry, launch expressibility

### DIFF
--- a/synth_ai/managed_research/models/run_launch.py
+++ b/synth_ai/managed_research/models/run_launch.py
@@ -205,6 +205,7 @@ class RunLaunchRequest(CommandRequest):
     runbook_config_id: str | None = None
     local_execution: WireMapping | None = None
     execution_profile: LocalExecutionProfile | WireMapping | None = None
+    execution_target: WireMapping | None = None
     timebox_seconds: int | None = None
     agent_profile: str | None = None
     agent_model: SmrAgentModel | str | None = None
@@ -271,6 +272,7 @@ class RunLaunchRequest(CommandRequest):
             runbook_config_id=self.runbook_config_id,
             local_execution=self.local_execution,
             execution_profile=self.execution_profile,
+            execution_target=self.execution_target,
             timebox_seconds=self.timebox_seconds,
             agent_profile=self.agent_profile,
             agent_model=self.agent_model,
@@ -1216,6 +1218,7 @@ def _validate_launch_sequences(request: RunLaunchRequest) -> None:
 def _validate_launch_mappings(request: RunLaunchRequest) -> None:
     mapping_fields = (
         "local_execution",
+        "execution_target",
         "agent_model_params",
         "workflow",
         "primary_parent_ref",

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -625,6 +625,7 @@ def _build_project_run_payload(
     runbook_config_id: str | None = None,
     local_execution: Mapping[str, Any] | dict[str, Any] | None = None,
     execution_profile: LocalExecutionProfile | Mapping[str, Any] | dict[str, Any] | None = None,
+    execution_target: Mapping[str, Any] | dict[str, Any] | None = None,
     timebox_seconds: int | None = None,
     agent_profile: str | None = None,
     agent_model: SmrAgentModel | str | None = None,
@@ -764,6 +765,12 @@ def _build_project_run_payload(
                 execution_profile,
                 field_name="execution_profile",
             )
+    normalized_execution_target = _optional_mapping(
+        execution_target,
+        field_name="execution_target",
+    )
+    if normalized_execution_target:
+        payload["execution_target"] = normalized_execution_target
     if normalized_horizon is not None:
         payload["intended_horizon_hours"] = int(normalized_horizon)
         if timebox_seconds is not None and int(timebox_seconds) != int(normalized_horizon) * 3600:
@@ -5328,6 +5335,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         runbook_config_id: str | None = None,
         local_execution: Mapping[str, Any] | dict[str, Any] | None = None,
         execution_profile: LocalExecutionProfile | Mapping[str, Any] | dict[str, Any] | None = None,
+        execution_target: Mapping[str, Any] | dict[str, Any] | None = None,
         timebox_seconds: int | None = None,
         agent_profile: str | None = None,
         agent_model: SmrAgentModel | str | None = None,
@@ -5376,6 +5384,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
             runbook_config_id=runbook_config_id,
             local_execution=local_execution,
             execution_profile=execution_profile,
+            execution_target=execution_target,
             timebox_seconds=timebox_seconds,
             agent_profile=agent_profile,
             agent_model=agent_model,
@@ -5476,6 +5485,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
         runbook_config_id: str | None = None,
         local_execution: Mapping[str, Any] | dict[str, Any] | None = None,
         execution_profile: LocalExecutionProfile | Mapping[str, Any] | dict[str, Any] | None = None,
+        execution_target: Mapping[str, Any] | dict[str, Any] | None = None,
         timebox_seconds: int | None = None,
         agent_profile: str | None = None,
         agent_model: SmrAgentModel | str | None = None,
@@ -5525,6 +5535,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
             runbook_config_id=runbook_config_id,
             local_execution=local_execution,
             execution_profile=execution_profile,
+            execution_target=execution_target,
             timebox_seconds=timebox_seconds,
             agent_profile=agent_profile,
             agent_model=agent_model,

--- a/synth_ai/research/__init__.py
+++ b/synth_ai/research/__init__.py
@@ -55,6 +55,9 @@ from synth_ai.research.swarms import (
     ResearchSwarmHandle,
     ResearchSwarmsAPI,
     ResearchSwarmSession,
+    SwarmResult,
+    SwarmRetryResult,
+    swarm_state_is_terminal,
 )
 
 # Deprecated run-noun aliases (public noun is Swarm; import shims live in
@@ -113,4 +116,7 @@ __all__ = [
     "ResearchWorkMode",
     "ResearchWorkProduct",
     "ResearchWorkerRolePalette",
+    "SwarmResult",
+    "SwarmRetryResult",
+    "swarm_state_is_terminal",
 ]

--- a/synth_ai/research/swarms.py
+++ b/synth_ai/research/swarms.py
@@ -524,9 +524,7 @@ class ResearchSwarmsAPI:
         if timeout <= 0:
             raise ValueError("timeout must be greater than 0")
         run_kwargs = _research_run_kwargs(launch_kwargs)
-        preflight_kwargs = {
-            key: value for key, value in run_kwargs.items() if key != "run_kind"
-        }
+        preflight_kwargs = {key: value for key, value in run_kwargs.items() if key != "run_kind"}
         preflight = self._session.runs.launch_preflight(
             project_id,
             project=project,

--- a/synth_ai/research/swarms.py
+++ b/synth_ai/research/swarms.py
@@ -10,24 +10,37 @@ composed by Managed Factories through Efforts. The wire protocol still uses
 
 from __future__ import annotations
 
+import time
 import warnings
 from collections.abc import Iterator
-from typing import Any, List, cast
+from dataclasses import dataclass
+from typing import Any, List, Literal, cast
 
+from synth_ai.managed_research.errors import (
+    SmrApiError,
+    SmrConcurrentRunLimitExceededError,
+)
 from synth_ai.managed_research.models.canonical_usage import (
     SmrResourceLimitProgress,
     SmrResourceLimits,
+    SmrRunUsage,
 )
 from synth_ai.managed_research.models.run_control import (
     ManagedResearchRunControlAck,
 )
+from synth_ai.managed_research.models.run_diagnostics import SmrRunCostSummary
 from synth_ai.managed_research.models.run_events import RunRuntimeStreamEvent
 from synth_ai.managed_research.models.run_observability import (
     RunObservabilitySnapshot,
 )
+from synth_ai.managed_research.models.run_state import RunState
 from synth_ai.managed_research.sdk.client import ManagedResearchClient
 from synth_ai.managed_research.sdk.runs import ProjectSelector, RunHandle
-from synth_ai.research.models import ResearchRunbookPreset, ResearchSwarm
+from synth_ai.research.models import (
+    ResearchRunbookPreset,
+    ResearchSwarm,
+    ResearchWorkProduct,
+)
 from synth_ai.research.swarm_readouts import ResearchSwarmReadoutsMixin, _deprecated_method
 from synth_ai.sdk.pagination import SyncPage
 
@@ -126,6 +139,131 @@ def _research_run_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _swallow_readout_errors(fetch: Any) -> Any:
+    """Best-effort readout fetch for failed swarms only; returns None on error."""
+    try:
+        return fetch()
+    except Exception:
+        return None
+
+
+def swarm_state_is_terminal(state: str) -> bool:
+    """Return whether a public swarm state string is terminal.
+
+    Reuses :class:`RunState` (the same terminal-state source the low-level
+    wait/contract path is projected from) instead of hand-authoring a string
+    set. Unknown states are non-terminal.
+    """
+    try:
+        parsed = RunState(str(state or "").strip().lower())
+    except ValueError:
+        return False
+    return parsed.is_terminal
+
+
+def classify_event_kind(kind: str) -> str:
+    """Classify a wire event ``kind`` into a coarse forward-compatible category.
+
+    Returns one of ``"tool"``, ``"message"``, ``"turn"``, ``"usage"``,
+    ``"status"``, or ``"other"``. Unknown kinds always classify as ``"other"``
+    so new backend event kinds never break consumers.
+    """
+    text = str(kind or "").strip().lower()
+    if not text:
+        return "other"
+    if text.startswith("tool"):
+        return "tool"
+    if text.startswith(("message", "operator.message", "runtime.message", "reasoning")):
+        return "message"
+    if text.startswith("turn"):
+        return "turn"
+    if text.startswith(("token", "usage")):
+        return "usage"
+    if ".state.changed" in text or text in {"heartbeat", "snapshot"}:
+        return "status"
+    return "other"
+
+
+class SwarmPreflightBlockedError(SmrApiError):
+    """Raised when ``launch_and_wait`` preflight is not clear to trigger.
+
+    Carries the structured ``blockers`` list and the full preflight payload so
+    callers can act on the class of denial rather than a bare message.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        blockers: list[dict[str, Any]],
+        preflight: dict[str, Any],
+    ) -> None:
+        super().__init__(message)
+        self.blockers = blockers
+        self.preflight = preflight
+
+
+class SwarmLaunchBackpressureError(SmrApiError):
+    """Raised when swarm launch exhausts its bounded backpressure retries."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        attempts: int,
+        last_error: SmrApiError,
+    ) -> None:
+        super().__init__(message, status_code=last_error.status_code)
+        self.attempts = attempts
+        self.last_error = last_error
+
+
+_LAUNCH_RETRY_MAX_ATTEMPTS = 5
+_LAUNCH_RETRY_MAX_SLEEP_SECONDS = 30.0
+_LAUNCH_RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
+
+
+def _is_retryable_launch_error(exc: SmrApiError) -> bool:
+    if isinstance(exc, SmrConcurrentRunLimitExceededError):
+        return True
+    return exc.status_code in _LAUNCH_RETRYABLE_STATUS_CODES
+
+
+@dataclass(frozen=True)
+class SwarmResult:
+    """Typed outcome of :meth:`ResearchSwarmsAPI.launch_and_wait`."""
+
+    swarm: ResearchSwarm
+    swarm_id: str
+    project_id: str
+    status: str
+    is_success: bool
+    usage: SmrRunUsage | None
+    cost: SmrRunCostSummary | None
+    work_products: List[ResearchWorkProduct]
+    handle: ResearchSwarmHandle
+
+    @property
+    def is_terminal(self) -> bool:
+        return swarm_state_is_terminal(self.status)
+
+
+@dataclass(frozen=True)
+class SwarmRetryResult:
+    """Typed outcome of :meth:`ResearchSwarmHandle.retry`.
+
+    Provenance (which swarm this retry came from and why) lives here
+    client-side; the launch wire has no metadata field to carry it.
+    """
+
+    source_swarm_id: str
+    new_swarm_id: str
+    mode: str
+    reason: str | None
+    checkpoint_id: str | None
+    handle: ResearchSwarmHandle
+
+
 class ResearchSwarmHandle(ResearchSwarmReadoutsMixin, RunHandle):
     """Swarm-scoped readouts and lifecycle (public hero session type).
 
@@ -141,6 +279,84 @@ class ResearchSwarmHandle(ResearchSwarmReadoutsMixin, RunHandle):
     def swarm_id(self) -> str:
         """Public swarm identifier (wire transport still calls this ``run_id``)."""
         return self.run_id
+
+    def wait_until_terminal(
+        self,
+        timeout: float,
+        poll_interval: float = 10.0,
+    ) -> ResearchSwarm:
+        """Block until the swarm reaches a terminal state (thin over ``wait``).
+
+        Args:
+            timeout: Max seconds to wait; the operator owns the wall clock.
+            poll_interval: Seconds between status polls.
+
+        Returns:
+            Final :class:`ResearchSwarm` public state model.
+        """
+        return self.wait(timeout=timeout, poll_interval=poll_interval)
+
+    def is_terminal(self) -> bool:
+        """Return whether the swarm has reached a terminal state.
+
+        Uses the backend run contract's ``terminal`` flag — the same authority
+        the low-level wait loop polls.
+        """
+        return self.contract().terminal
+
+    def retry(
+        self,
+        mode: Literal["from_checkpoint", "fresh"] = "fresh",
+        *,
+        reason: str | None = None,
+        checkpoint_id: str | None = None,
+    ) -> SwarmRetryResult:
+        """Retry a terminal swarm, either fresh or branched from a checkpoint.
+
+        Args:
+            mode: ``"fresh"`` re-launches the project's configured swarm;
+                ``"from_checkpoint"`` branches from an existing checkpoint.
+            reason: Optional operator reason, recorded client-side on the
+                result (and on the branch request for checkpoint retries).
+            checkpoint_id: Required when ``mode="from_checkpoint"``.
+
+        Returns:
+            :class:`SwarmRetryResult` with the new swarm id and handle.
+
+        Raises:
+            ValueError: If the source swarm is not terminal, or the mode /
+                checkpoint arguments are inconsistent.
+        """
+        if mode not in ("from_checkpoint", "fresh"):
+            raise ValueError(f"mode must be 'from_checkpoint' or 'fresh', got {mode!r}")
+        state = self.get().public_state
+        if not state.is_terminal:
+            raise ValueError(
+                f"swarm {self.swarm_id} is not terminal (state {state.value}); "
+                "retry requires a terminal source swarm"
+            )
+        if mode == "from_checkpoint":
+            if checkpoint_id is None:
+                raise ValueError("checkpoint_id is required when mode is 'from_checkpoint'")
+            branch = self.branch_from_checkpoint(
+                checkpoint_id=checkpoint_id,
+                reason=reason,
+            )
+            new_swarm_id = branch.child_run_id
+        else:
+            if checkpoint_id is not None:
+                raise ValueError("checkpoint_id is only valid when mode is 'from_checkpoint'")
+            wire = self._client.runs.trigger(self.project_id)
+            new_swarm_id = ResearchSwarm.from_wire(wire).run_id
+        new_handle = ResearchSwarmHandle(self._client.run(self.project_id, new_swarm_id))
+        return SwarmRetryResult(
+            source_swarm_id=self.swarm_id,
+            new_swarm_id=new_swarm_id,
+            mode=mode,
+            reason=reason,
+            checkpoint_id=checkpoint_id,
+            handle=new_handle,
+        )
 
     def progress_snapshot(
         self,
@@ -269,6 +485,156 @@ class ResearchSwarmsAPI:
             project=project,
             **_research_run_kwargs(kwargs),
         )
+
+    def launch_and_wait(
+        self,
+        project_id: str | None = None,
+        *,
+        project: ProjectSelector | str | None = None,
+        objective: str | None = None,
+        timeout: float,
+        poll_interval: float = 10.0,
+        raise_if_failed: bool = False,
+        **launch_kwargs: Any,
+    ) -> SwarmResult:
+        """Preflight, launch, and wait for a swarm in one call (hero flow).
+
+        Runs ``check_preflight`` first and fails immediately with a typed
+        :class:`SwarmPreflightBlockedError` when not clear to trigger. Launch
+        is wrapped in a bounded backpressure retry (HTTP 502/503/504 and
+        concurrent-run-limit backpressure, max 5 attempts, capped
+        backoff); other errors raise immediately. Then blocks until terminal
+        and assembles a typed :class:`SwarmResult`.
+
+        Args:
+            project_id: Owning project id.
+            objective: Primary operator message (objective launch path). When
+                omitted, the project's configured swarm is triggered.
+            timeout: REQUIRED max seconds to wait for terminal state — the
+                operator owns the wall clock; there is no wait-forever default.
+            poll_interval: Seconds between status polls.
+            raise_if_failed: Raise when the swarm ends failed/blocked.
+            **launch_kwargs: Any launch-request field the backend accepts
+                (``execution_target``, ``local_execution``, ``limit``, ...).
+
+        Returns:
+            :class:`SwarmResult` with final state, usage, cost, work products,
+            and a live handle for further readouts.
+        """
+        if timeout <= 0:
+            raise ValueError("timeout must be greater than 0")
+        run_kwargs = _research_run_kwargs(launch_kwargs)
+        preflight_kwargs = {
+            key: value for key, value in run_kwargs.items() if key != "run_kind"
+        }
+        preflight = self._session.runs.launch_preflight(
+            project_id,
+            project=project,
+            objective=objective,
+            **preflight_kwargs,
+        )
+        clear = preflight.get("clear_to_trigger")
+        if clear is None:
+            clear = preflight.get("allowed")
+        if not clear:
+            blockers_payload = preflight.get("blockers") or preflight.get("checks") or []
+            blockers = [item for item in blockers_payload if isinstance(item, dict)]
+            names = ", ".join(
+                str(item.get("blocker") or item.get("check") or item.get("kind") or "unnamed")
+                for item in blockers
+            )
+            raise SwarmPreflightBlockedError(
+                "swarm launch preflight is not clear to trigger"
+                + (f"; blockers: {names}" if names else ""),
+                blockers=blockers,
+                preflight=preflight,
+            )
+        handle = self._launch_with_backpressure_retry(
+            project_id,
+            project=project,
+            objective=objective,
+            run_kwargs=run_kwargs,
+        )
+        swarm = handle.wait(
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_if_failed=raise_if_failed,
+        )
+        status = swarm.public_state.value
+        is_success = swarm.public_state is RunState.DONE
+        if is_success:
+            usage: SmrRunUsage | None = handle.usage.get()
+            cost: SmrRunCostSummary | None = handle.usage.cost.get()
+            work_products = list(handle.work_products.list())
+        else:
+            usage = _swallow_readout_errors(handle.usage.get)
+            cost = _swallow_readout_errors(handle.usage.cost.get)
+            work_products = _swallow_readout_errors(handle.work_products.list) or []
+        return SwarmResult(
+            swarm=swarm,
+            swarm_id=handle.swarm_id,
+            project_id=handle.project_id,
+            status=status,
+            is_success=is_success,
+            usage=usage,
+            cost=cost,
+            work_products=list(work_products),
+            handle=handle,
+        )
+
+    def _launch_handle(
+        self,
+        project_id: str | None,
+        *,
+        project: ProjectSelector | str | None,
+        objective: str | None,
+        run_kwargs: dict[str, Any],
+    ) -> ResearchSwarmHandle:
+        if objective is not None:
+            handle = self._session.runs.start(
+                objective,
+                project_id=project_id,
+                project=project,
+                **run_kwargs,
+            )
+            return ResearchSwarmHandle(handle)
+        wire = self._session.runs.trigger(
+            project_id,
+            project=project,
+            **run_kwargs,
+        )
+        run = ResearchSwarm.from_wire(wire)
+        return ResearchSwarmHandle(self._session.run(run.project_id, run.run_id))
+
+    def _launch_with_backpressure_retry(
+        self,
+        project_id: str | None,
+        *,
+        project: ProjectSelector | str | None,
+        objective: str | None,
+        run_kwargs: dict[str, Any],
+    ) -> ResearchSwarmHandle:
+        for attempt in range(1, _LAUNCH_RETRY_MAX_ATTEMPTS + 1):
+            try:
+                return self._launch_handle(
+                    project_id,
+                    project=project,
+                    objective=objective,
+                    run_kwargs=run_kwargs,
+                )
+            except SmrApiError as exc:
+                if not _is_retryable_launch_error(exc):
+                    raise
+                if attempt == _LAUNCH_RETRY_MAX_ATTEMPTS:
+                    raise SwarmLaunchBackpressureError(
+                        f"swarm launch exhausted {_LAUNCH_RETRY_MAX_ATTEMPTS} attempts on "
+                        f"retryable backpressure ({type(exc).__name__}, "
+                        f"status_code={exc.status_code}): {exc}",
+                        attempts=_LAUNCH_RETRY_MAX_ATTEMPTS,
+                        last_error=exc,
+                    ) from exc
+                time.sleep(min(2.0**attempt, _LAUNCH_RETRY_MAX_SLEEP_SECONDS))
+        raise RuntimeError("unreachable: launch retry loop must return or raise")
 
     def launch_preflight(
         self,
@@ -715,4 +1081,14 @@ class ResearchSwarmsAPI:
 
 ResearchSwarmSession = ResearchSwarmHandle
 
-__all__ = ["ResearchSwarmHandle", "ResearchSwarmSession", "ResearchSwarmsAPI"]
+__all__ = [
+    "ResearchSwarmHandle",
+    "ResearchSwarmSession",
+    "ResearchSwarmsAPI",
+    "SwarmLaunchBackpressureError",
+    "SwarmPreflightBlockedError",
+    "SwarmResult",
+    "SwarmRetryResult",
+    "classify_event_kind",
+    "swarm_state_is_terminal",
+]

--- a/tests/research/test_swarm_hero_core.py
+++ b/tests/research/test_swarm_hero_core.py
@@ -1,0 +1,397 @@
+"""Core-ergonomics hero flows: launch_and_wait, retry, expressibility, terminal helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from synth_ai.managed_research.errors import SmrApiError
+from synth_ai.managed_research.models.run_state import RunState
+from synth_ai.managed_research.sdk.client import _build_project_run_payload
+from synth_ai.managed_research.sdk.runs import RunHandle
+from synth_ai.research.swarms import (
+    ResearchSwarmHandle,
+    ResearchSwarmsAPI,
+    SwarmLaunchBackpressureError,
+    SwarmPreflightBlockedError,
+    SwarmResult,
+    SwarmRetryResult,
+    classify_event_kind,
+    swarm_state_is_terminal,
+)
+
+_USAGE_SENTINEL = {"total_tokens": 123}
+_COST_SENTINEL = {"total_usd": 4.56}
+_WORK_PRODUCTS_SENTINEL = [{"work_product_id": "wp-1", "kind": "report"}]
+
+
+class _FakeRunsNamespace:
+    def __init__(self, client: FakeSessionClient) -> None:
+        self._client = client
+
+    def launch_preflight(
+        self,
+        project_id: str | None = None,
+        *,
+        project: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self._client.preflight_calls.append({"project_id": project_id, **kwargs})
+        return dict(self._client.preflight_payload)
+
+    def start(
+        self,
+        objective: str,
+        *,
+        project_id: str | None = None,
+        project: Any = None,
+        **kwargs: Any,
+    ) -> RunHandle:
+        self._client.start_calls.append({"objective": objective, **kwargs})
+        self._client.maybe_raise_launch_error()
+        return RunHandle(self._client, project_id or "proj-1", self._client.launched_run_id)
+
+    def trigger(
+        self,
+        project_id: str | None = None,
+        *,
+        project: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self._client.trigger_calls.append({"project_id": project_id, **kwargs})
+        self._client.maybe_raise_launch_error()
+        return {
+            "run_id": self._client.launched_run_id,
+            "project_id": project_id or "proj-1",
+            "public_state": "queued",
+        }
+
+
+class _FakeWorkProductsNamespace:
+    def __init__(self, client: FakeSessionClient) -> None:
+        self._client = client
+
+    def list_for_run(self, project_id: str, run_id: str) -> list[dict[str, Any]]:
+        if self._client.readouts_raise:
+            raise SmrApiError("work products unavailable", status_code=500)
+        return list(_WORK_PRODUCTS_SENTINEL)
+
+
+class FakeSessionClient:
+    """Duck-typed ManagedResearchClient standing in for the network client."""
+
+    def __init__(self) -> None:
+        self.runs = _FakeRunsNamespace(self)
+        self.work_products = _FakeWorkProductsNamespace(self)
+        self.preflight_payload: dict[str, Any] = {"clear_to_trigger": True, "blockers": []}
+        self.final_state = "done"
+        self.launched_run_id = "swarm-1"
+        self.launch_errors: list[SmrApiError] = []
+        self.readouts_raise = False
+        self.preflight_calls: list[dict[str, Any]] = []
+        self.start_calls: list[dict[str, Any]] = []
+        self.trigger_calls: list[dict[str, Any]] = []
+        self.branch_calls: list[dict[str, Any]] = []
+
+    def maybe_raise_launch_error(self) -> None:
+        if self.launch_errors:
+            raise self.launch_errors.pop(0)
+
+    def run(self, project_id: str, run_id: str) -> RunHandle:
+        return RunHandle(self, project_id, run_id)
+
+    def get_run_contract(self, project_id: str, run_id: str) -> Any:
+        return SimpleNamespace(
+            terminal=swarm_state_is_terminal(self.final_state),
+            public_state=SimpleNamespace(value=self.final_state),
+        )
+
+    def get_project_run(self, project_id: str, run_id: str) -> dict[str, Any]:
+        return {
+            "run_id": run_id,
+            "project_id": project_id,
+            "public_state": self.final_state,
+        }
+
+    def get_run_usage(self, run_id: str) -> dict[str, Any]:
+        if self.readouts_raise:
+            raise SmrApiError("usage unavailable", status_code=500)
+        return dict(_USAGE_SENTINEL)
+
+    def get_run_cost_summary(self, run_id: str) -> dict[str, Any]:
+        if self.readouts_raise:
+            raise SmrApiError("cost unavailable", status_code=500)
+        return dict(_COST_SENTINEL)
+
+    def branch_run_from_checkpoint(self, run_id: str, **kwargs: Any) -> Any:
+        self.branch_calls.append({"run_id": run_id, **kwargs})
+        return SimpleNamespace(child_run_id="swarm-2", parent_run_id=run_id)
+
+
+def _api(client: FakeSessionClient) -> ResearchSwarmsAPI:
+    return ResearchSwarmsAPI(client)  # type: ignore[arg-type]
+
+
+def _handle(client: FakeSessionClient, run_id: str = "swarm-1") -> ResearchSwarmHandle:
+    return ResearchSwarmHandle(RunHandle(client, "proj-1", run_id))
+
+
+# --- launch_and_wait -----------------------------------------------------------
+
+
+def test_launch_and_wait_success_fetches_typed_readouts() -> None:
+    client = FakeSessionClient()
+    result = _api(client).launch_and_wait(
+        "proj-1",
+        objective="Audit the repo",
+        timeout=60.0,
+    )
+    assert isinstance(result, SwarmResult)
+    assert result.swarm_id == "swarm-1"
+    assert result.project_id == "proj-1"
+    assert result.status == "done"
+    assert result.is_success is True
+    assert result.is_terminal is True
+    assert result.usage == _USAGE_SENTINEL
+    assert result.cost == _COST_SENTINEL
+    assert result.work_products == _WORK_PRODUCTS_SENTINEL
+    assert isinstance(result.handle, ResearchSwarmHandle)
+    assert result.swarm.public_state is RunState.DONE
+    assert len(client.preflight_calls) == 1
+
+
+def test_launch_and_wait_timeout_is_required_and_positive() -> None:
+    client = FakeSessionClient()
+    with pytest.raises(TypeError):
+        _api(client).launch_and_wait("proj-1", objective="x")  # type: ignore[call-arg]
+    with pytest.raises(ValueError, match="timeout"):
+        _api(client).launch_and_wait("proj-1", objective="x", timeout=0.0)
+
+
+def test_launch_and_wait_preflight_blocked_raises_typed_error() -> None:
+    client = FakeSessionClient()
+    client.preflight_payload = {
+        "clear_to_trigger": False,
+        "blockers": [{"blocker": "missing_repo"}, {"blocker": "no_budget"}],
+    }
+    with pytest.raises(SwarmPreflightBlockedError) as excinfo:
+        _api(client).launch_and_wait("proj-1", objective="x", timeout=5.0)
+    assert excinfo.value.blockers == [
+        {"blocker": "missing_repo"},
+        {"blocker": "no_budget"},
+    ]
+    assert "missing_repo" in str(excinfo.value)
+    assert client.start_calls == []
+
+
+def test_launch_and_wait_retries_backpressure_then_exhausts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "synth_ai.research.swarms.time.sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
+    client = FakeSessionClient()
+    client.launch_errors = [SmrApiError("edge 503", status_code=503) for _ in range(5)]
+    with pytest.raises(SwarmLaunchBackpressureError) as excinfo:
+        _api(client).launch_and_wait("proj-1", objective="x", timeout=5.0)
+    assert excinfo.value.attempts == 5
+    assert excinfo.value.last_error.status_code == 503
+    assert "SmrApiError" in str(excinfo.value)
+    assert len(sleeps) == 4
+    assert all(seconds <= 30.0 for seconds in sleeps)
+
+
+def test_launch_and_wait_retries_transient_backpressure_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("synth_ai.research.swarms.time.sleep", lambda seconds: None)
+    client = FakeSessionClient()
+    client.launch_errors = [SmrApiError("edge 502", status_code=502)]
+    result = _api(client).launch_and_wait("proj-1", objective="x", timeout=5.0)
+    assert result.is_success is True
+    assert len(client.start_calls) == 2
+
+
+def test_launch_and_wait_non_retryable_error_raises_immediately() -> None:
+    client = FakeSessionClient()
+    client.launch_errors = [SmrApiError("bad request", status_code=422)]
+    with pytest.raises(SmrApiError) as excinfo:
+        _api(client).launch_and_wait("proj-1", objective="x", timeout=5.0)
+    assert not isinstance(excinfo.value, SwarmLaunchBackpressureError)
+    assert len(client.start_calls) == 1
+
+
+def test_launch_and_wait_failed_swarm_uses_best_effort_readouts() -> None:
+    client = FakeSessionClient()
+    client.final_state = "failed"
+    client.readouts_raise = True
+    result = _api(client).launch_and_wait("proj-1", objective="x", timeout=5.0)
+    assert result.is_success is False
+    assert result.status == "failed"
+    assert result.is_terminal is True
+    assert result.usage is None
+    assert result.cost is None
+    assert result.work_products == []
+
+
+def test_launch_and_wait_configured_path_uses_trigger() -> None:
+    client = FakeSessionClient()
+    result = _api(client).launch_and_wait("proj-1", timeout=5.0)
+    assert result.is_success is True
+    assert len(client.trigger_calls) == 1
+    assert client.start_calls == []
+
+
+# --- launch expressibility -----------------------------------------------------
+
+
+def test_build_project_run_payload_passes_execution_target_and_local_launch() -> None:
+    payload = _build_project_run_payload(
+        local_execution={"slot": "slot-2"},
+        execution_profile={"profile": "local-dev"},
+        execution_target={"kind": "slot", "slot_id": "slot-2"},
+    )
+    assert payload["local_execution"] == {"slot": "slot-2"}
+    assert payload["execution_profile"] == {"profile": "local-dev"}
+    assert payload["execution_target"] == {"kind": "slot", "slot_id": "slot-2"}
+
+
+def test_run_launch_request_accepts_execution_target() -> None:
+    from synth_ai.managed_research.models.run_launch import RunLaunchRequest
+
+    request = RunLaunchRequest(
+        runbook_preset="quick",
+        execution_target={"kind": "slot", "slot_id": "slot-2"},
+        local_execution={"slot": "slot-2"},
+    )
+    kwargs = request.to_client_kwargs()
+    assert kwargs["execution_target"] == {"kind": "slot", "slot_id": "slot-2"}
+    wire = request.to_wire()
+    assert wire["execution_target"] == {"kind": "slot", "slot_id": "slot-2"}
+    assert wire["local_execution"] == {"slot": "slot-2"}
+
+
+def test_facade_create_configured_passes_execution_target_through() -> None:
+    client = FakeSessionClient()
+    handle = _api(client).create_configured(
+        "proj-1",
+        execution_target={"kind": "slot", "slot_id": "slot-2"},
+        local_execution={"slot": "slot-2"},
+    )
+    assert isinstance(handle, ResearchSwarmHandle)
+    (call,) = client.trigger_calls
+    assert call["execution_target"] == {"kind": "slot", "slot_id": "slot-2"}
+    assert call["local_execution"] == {"slot": "slot-2"}
+
+
+def test_launch_and_wait_passes_execution_target_to_preflight_and_launch() -> None:
+    client = FakeSessionClient()
+    _api(client).launch_and_wait(
+        "proj-1",
+        timeout=5.0,
+        execution_target={"kind": "slot", "slot_id": "slot-2"},
+    )
+    (preflight_call,) = client.preflight_calls
+    (trigger_call,) = client.trigger_calls
+    assert preflight_call["execution_target"] == {"kind": "slot", "slot_id": "slot-2"}
+    assert trigger_call["execution_target"] == {"kind": "slot", "slot_id": "slot-2"}
+
+
+# --- retry ---------------------------------------------------------------------
+
+
+def test_retry_rejects_non_terminal_swarm_with_state_name() -> None:
+    client = FakeSessionClient()
+    client.final_state = "running"
+    with pytest.raises(ValueError, match="running"):
+        _handle(client).retry()
+
+
+def test_retry_fresh_relaunches_configured_swarm() -> None:
+    client = FakeSessionClient()
+    client.final_state = "failed"
+    client.launched_run_id = "swarm-2"
+    result = _handle(client).retry(reason="flaky infra")
+    assert isinstance(result, SwarmRetryResult)
+    assert result.source_swarm_id == "swarm-1"
+    assert result.new_swarm_id == "swarm-2"
+    assert result.mode == "fresh"
+    assert result.reason == "flaky infra"
+    assert result.checkpoint_id is None
+    assert result.handle.swarm_id == "swarm-2"
+    assert len(client.trigger_calls) == 1
+
+
+def test_retry_from_checkpoint_branches_from_checkpoint() -> None:
+    client = FakeSessionClient()
+    client.final_state = "failed"
+    result = _handle(client).retry(
+        "from_checkpoint",
+        reason="resume after fix",
+        checkpoint_id="ckpt-9",
+    )
+    assert result.mode == "from_checkpoint"
+    assert result.new_swarm_id == "swarm-2"
+    assert result.checkpoint_id == "ckpt-9"
+    assert result.handle.swarm_id == "swarm-2"
+    (call,) = client.branch_calls
+    assert call["checkpoint_id"] == "ckpt-9"
+    assert call["reason"] == "resume after fix"
+
+
+def test_retry_argument_gating() -> None:
+    client = FakeSessionClient()
+    client.final_state = "done"
+    with pytest.raises(ValueError, match="checkpoint_id"):
+        _handle(client).retry("from_checkpoint")
+    with pytest.raises(ValueError, match="checkpoint_id"):
+        _handle(client).retry("fresh", checkpoint_id="ckpt-9")
+    with pytest.raises(ValueError, match="mode"):
+        _handle(client).retry("sideways")  # type: ignore[arg-type]
+
+
+# --- observe polish ------------------------------------------------------------
+
+
+def test_wait_until_terminal_returns_final_state() -> None:
+    client = FakeSessionClient()
+    swarm = _handle(client).wait_until_terminal(timeout=5.0)
+    assert swarm.public_state is RunState.DONE
+
+
+def test_handle_is_terminal_uses_contract_authority() -> None:
+    client = FakeSessionClient()
+    assert _handle(client).is_terminal() is True
+    client.final_state = "running"
+    assert _handle(client).is_terminal() is False
+
+
+def test_swarm_state_is_terminal_reuses_run_state_source() -> None:
+    for state in RunState:
+        assert swarm_state_is_terminal(state.value) == state.is_terminal
+    assert swarm_state_is_terminal("some_future_state") is False
+    assert swarm_state_is_terminal("") is False
+
+
+@pytest.mark.parametrize(
+    ("kind", "category"),
+    [
+        ("tool.call.started", "tool"),
+        ("tool.call.completed", "tool"),
+        ("message.delta", "message"),
+        ("operator.message.sent", "message"),
+        ("reasoning.summary", "message"),
+        ("turn.completed", "turn"),
+        ("token.usage", "usage"),
+        ("run.state.changed", "status"),
+        ("task.state.changed", "status"),
+        ("heartbeat", "status"),
+        ("some.future.kind", "other"),
+        ("", "other"),
+    ],
+)
+def test_classify_event_kind(kind: str, category: str) -> None:
+    assert classify_event_kind(kind) == category


### PR DESCRIPTION
Core-ergonomics tranche of the Managed Swarm SDK redesign, stacked on #296 (Run→Swarm noun facade).

## What

### `swarms.launch_and_wait(...) -> SwarmResult`
One-call hero flow: `check_preflight` → launch → wait-to-terminal → typed result.
- Preflight not clear (`clear_to_trigger`/`allowed` false) fails immediately with typed `SwarmPreflightBlockedError` carrying the structured `blockers` list and full preflight payload.
- Bounded backpressure retry around launch **only**: HTTP 502/503/504 + `SmrConcurrentRunLimitExceededError`, max 5 attempts, backoff capped at 30s per sleep; exhaustion raises `SwarmLaunchBackpressureError` naming the failure class and status code. Non-retryable errors raise immediately.
- `timeout` is REQUIRED (keyword-only, no default-forever) — the operator owns the wall clock.
- `SwarmResult` (frozen dataclass): `swarm`, `swarm_id`, `project_id`, `status`, `is_success`, `usage` (`SmrRunUsage`), `cost` (`SmrRunCostSummary`), `work_products`, `handle`, plus `is_terminal`. Usage/cost/work-products are fetched for real on success (no silent None on the happy path); best-effort only when the swarm failed.

### Launch expressibility
`execution_target` now flows through the typed path end to end: `_build_project_run_payload`, `trigger_run`, `get_launch_preflight`, and `RunLaunchRequest` (field + validation + `to_client_kwargs`). Combined with the already-supported `local_execution`/`execution_profile`, every launch shape evals' `reportbench/client_api.py` sends via raw `_request_json` is now expressible through `swarms.create` / `create_configured` / `launch_and_wait` (facade `**kwargs` pass through untouched).

### `handle.retry(mode="fresh"|"from_checkpoint") -> SwarmRetryResult`
- Terminal-only gating: non-terminal source raises `ValueError` naming the actual state.
- `from_checkpoint` reuses the existing `branch_from_checkpoint` primitive (requires `checkpoint_id`); `fresh` re-triggers the project's configured swarm.
- Provenance (`source_swarm_id`, `reason`, `checkpoint_id`) lives client-side on the typed result — the launch wire has no metadata field, verified, so no backend provenance was invented.

### Observe polish
- `handle.wait_until_terminal(timeout, poll_interval)` — thin delegate over `wait`.
- `handle.is_terminal()` — backend run-contract `terminal` flag (same authority the low-level wait polls).
- `swarm_state_is_terminal(state)` — reuses `RunState.is_terminal` (the canonical terminal set), unknown states → False; also exposed as `SwarmResult.is_terminal`.
- `classify_event_kind(kind)` — coarse forward-compatible categories (`tool`/`message`/`turn`/`usage`/`status`/`other`); unknown kinds always classify `other`.

`synth_ai/research/__init__.py` edits are append-only (`SwarmResult`, `SwarmRetryResult`, `swarm_state_is_terminal`).

## Tests
`uv run pytest tests/ -q` → **48 passed** (26 new in `tests/research/test_swarm_hero_core.py`, fake session client, no network): hero-flow success/blocked/backpressure-exhaustion/transient-recovery/failed-run best-effort, retry gating + both modes, expressibility pass-through (payload builder, `RunLaunchRequest`, facade), terminal-helper reuse across all `RunState` members, event-kind classification. `uv run ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)