### PR TITLE
Factory usage/events + account readiness bindings; trigger_result fix

### DIFF
--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -5579,7 +5579,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
     ) -> RunLaunchResult:
         return RunLaunchResult.from_wire(
             project_id=project_id,
-            payload=self.trigger_run(project_id, request=request),
+            payload=self.trigger_run(project_id, **request.to_client_kwargs()),
         )
 
     def start_run(self, project_id: str, **kwargs: Any) -> dict[str, Any]:

--- a/synth_ai/research/account.py
+++ b/synth_ai/research/account.py
@@ -101,6 +101,73 @@ class AccountByokStatus:
 
 
 @dataclass(frozen=True)
+class AccountReadinessCta:
+    """Typed ``AccountReadinessCta`` (call-to-action for a failing check)."""
+
+    label: str
+    href: str
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> AccountReadinessCta:
+        mapping = _require_account_mapping(payload, label="account readiness cta")
+        return cls(
+            label=str(mapping.get("label") or ""),
+            href=str(mapping.get("href") or ""),
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class AccountReadinessCheck:
+    """Typed ``AccountReadinessCheck`` (one readiness gate with optional CTA)."""
+
+    id: str
+    ok: bool
+    label: str
+    cta: AccountReadinessCta | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> AccountReadinessCheck:
+        mapping = _require_account_mapping(payload, label="account readiness check")
+        cta = mapping.get("cta")
+        metadata = mapping.get("metadata")
+        return cls(
+            id=str(mapping.get("id") or ""),
+            ok=bool(mapping.get("ok")),
+            label=str(mapping.get("label") or ""),
+            cta=AccountReadinessCta.from_wire(cta) if cta is not None else None,
+            metadata=_require_account_mapping(metadata, label="account readiness metadata")
+            if isinstance(metadata, Mapping)
+            else {},
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class AccountReadiness:
+    """Typed ``AccountReadinessResponse`` (org-level launch readiness with CTAs)."""
+
+    ready: bool
+    checks: tuple[AccountReadinessCheck, ...] = ()
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> AccountReadiness:
+        mapping = _require_account_mapping(payload, label="account readiness")
+        return cls(
+            ready=bool(mapping.get("ready")),
+            checks=tuple(
+                AccountReadinessCheck.from_wire(item)
+                for item in list(mapping.get("checks") or [])
+            ),
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
 class AccountIdentity:
     """Typed ``MeResponse`` (org and user resolution for the API key)."""
 
@@ -451,6 +518,15 @@ class ResearchAccountAPI:
             )
         )
 
+    def readiness(self) -> AccountReadiness:
+        """Read org account readiness checks (balance, runway, tier headroom, BYOK).
+
+        Backend route: ``GET /api/v1/account/readiness``.
+        """
+        return AccountReadiness.from_wire(
+            self._session._request_json("GET", "/api/v1/account/readiness")
+        )
+
     def me(self) -> AccountIdentity:
         """Resolve the org/user identity for the API key.
 
@@ -463,6 +539,9 @@ __all__ = [
     "AccountBalance",
     "AccountByokStatus",
     "AccountIdentity",
+    "AccountReadiness",
+    "AccountReadinessCheck",
+    "AccountReadinessCta",
     "AccountTierLimits",
     "ResearchAccountAPI",
     "ResearchAccountBalanceAPI",

--- a/synth_ai/research/account.py
+++ b/synth_ai/research/account.py
@@ -88,9 +88,7 @@ class AccountByokStatus:
             plan_type=str(mapping.get("plan_type") or ""),
             providers_with_keys={
                 str(key): bool(value)
-                for key, value in dict(
-                    providers if isinstance(providers, Mapping) else {}
-                ).items()
+                for key, value in dict(providers if isinstance(providers, Mapping) else {}).items()
             },
             supported_providers=tuple(
                 str(item) for item in list(mapping.get("supported_providers") or [])
@@ -164,8 +162,7 @@ class AccountReadiness:
         return cls(
             ready=bool(mapping.get("ready")),
             checks=tuple(
-                AccountReadinessCheck.from_wire(item)
-                for item in list(mapping.get("checks") or [])
+                AccountReadinessCheck.from_wire(item) for item in list(mapping.get("checks") or [])
             ),
             raw=dict(mapping),
         )
@@ -536,9 +533,7 @@ class ResearchAccountAPI:
 
         Backend route: ``GET /api/v1/me``.
         """
-        return AccountIdentity.from_wire(
-            self._session._request_json("GET", "/api/v1/me")
-        )
+        return AccountIdentity.from_wire(self._session._request_json("GET", "/api/v1/me"))
 
 
 __all__ = [

--- a/synth_ai/research/account.py
+++ b/synth_ai/research/account.py
@@ -88,7 +88,9 @@ class AccountByokStatus:
             plan_type=str(mapping.get("plan_type") or ""),
             providers_with_keys={
                 str(key): bool(value)
-                for key, value in dict(providers if isinstance(providers, Mapping) else {}).items()
+                for key, value in dict(
+                    providers if isinstance(providers, Mapping) else {}
+                ).items()
             },
             supported_providers=tuple(
                 str(item) for item in list(mapping.get("supported_providers") or [])
@@ -139,9 +141,11 @@ class AccountReadinessCheck:
             ok=bool(mapping.get("ok")),
             label=str(mapping.get("label") or ""),
             cta=AccountReadinessCta.from_wire(cta) if cta is not None else None,
-            metadata=_require_account_mapping(metadata, label="account readiness metadata")
-            if isinstance(metadata, Mapping)
-            else {},
+            metadata=(
+                _require_account_mapping(metadata, label="account readiness metadata")
+                if isinstance(metadata, Mapping)
+                else {}
+            ),
             raw=dict(mapping),
         )
 
@@ -532,7 +536,9 @@ class ResearchAccountAPI:
 
         Backend route: ``GET /api/v1/me``.
         """
-        return AccountIdentity.from_wire(self._session._request_json("GET", "/api/v1/me"))
+        return AccountIdentity.from_wire(
+            self._session._request_json("GET", "/api/v1/me")
+        )
 
 
 __all__ = [

--- a/synth_ai/research/factories.py
+++ b/synth_ai/research/factories.py
@@ -33,6 +33,13 @@ from synth_ai.research.factory_handles import (
     ResearchFactoryEffortsAPI,
     ResearchFactoryHandle,
 )
+from synth_ai.research.factory_usage import (
+    FactoryEvent,
+    FactoryEventsPage,
+    FactoryUsage,
+    fetch_factory_events,
+    fetch_factory_usage,
+)
 
 
 class ResearchFactoriesTagSessionsMessagesAPI:
@@ -360,6 +367,55 @@ class ResearchFactoriesAPI:
             stop_when_idle=stop_when_idle,
         )
 
+    def usage(
+        self,
+        factory_id: str,
+        *,
+        window: str = "month_to_date",
+    ) -> FactoryUsage:
+        """Read the factory-level usage aggregate (cost, budget, per-effort drawdown).
+
+        Backend route: ``GET /smr/factories/{factory_id}/usage``
+        (query ``window``: ``month_to_date`` | ``last_7_days``).
+        """
+        return fetch_factory_usage(self._session, factory_id, window=window)
+
+    def events(
+        self,
+        factory_id: str,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+    ) -> FactoryEventsPage:
+        """Read one newest-first page of durable factory events.
+
+        Backend route: ``GET /smr/factories/{factory_id}/events``
+        (query ``limit`` 1-500, ``cursor``).
+        """
+        return fetch_factory_events(self._session, factory_id, limit=limit, cursor=cursor)
+
+    def iter_events(
+        self,
+        factory_id: str,
+        *,
+        limit: int | None = None,
+    ) -> Iterator[FactoryEvent]:
+        """Yield durable factory events, paging until ``next_cursor`` drains.
+
+        Backend route: repeated ``GET /smr/factories/{factory_id}/events``.
+        Stops when ``next_cursor`` is null or repeats (bounded; no sleeps).
+        """
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+        while True:
+            page = self.events(factory_id, limit=limit, cursor=cursor)
+            yield from page.events
+            next_cursor = page.next_cursor
+            if next_cursor is None or next_cursor in seen_cursors:
+                return
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
     def preview_wake(
         self,
         factory_id: str,
@@ -413,6 +469,9 @@ class ResearchFactoriesAPI:
 
 
 __all__ = [
+    "FactoryEvent",
+    "FactoryEventsPage",
+    "FactoryUsage",
     "ResearchEffortHandle",
     "ResearchFactoriesAPI",
     "ResearchFactoryEffortsAPI",

--- a/synth_ai/research/factory_handles.py
+++ b/synth_ai/research/factory_handles.py
@@ -12,6 +12,12 @@ from synth_ai.managed_research.models.factories import (
     FactoryWakeDueResult,
 )
 from synth_ai.managed_research.sdk.client import ManagedResearchClient
+from synth_ai.research.factory_usage import (
+    FactoryEventsPage,
+    FactoryUsage,
+    fetch_factory_events,
+    fetch_factory_usage,
+)
 
 if TYPE_CHECKING:
     from synth_ai.research.factories import ResearchFactoriesAPI
@@ -99,6 +105,32 @@ class ResearchFactoryHandle:
     def archive(self) -> Factory:
         """Archive the Factory. Backend route: ``PATCH /smr/factories/{factory_id}``."""
         return self._session.factories.archive(self.factory_id)
+
+    def usage(self, *, window: str = "month_to_date") -> FactoryUsage:
+        """Read the factory usage aggregate.
+
+        Backend route: ``GET /smr/factories/{factory_id}/usage``
+        (query ``window``: ``month_to_date`` | ``last_7_days``).
+        """
+        return fetch_factory_usage(self._session, self.factory_id, window=window)
+
+    def events(
+        self,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+    ) -> FactoryEventsPage:
+        """Read one newest-first page of durable factory events.
+
+        Backend route: ``GET /smr/factories/{factory_id}/events``
+        (query ``limit`` 1-500, ``cursor``).
+        """
+        return fetch_factory_events(
+            self._session,
+            self.factory_id,
+            limit=limit,
+            cursor=cursor,
+        )
 
     def watch_status(
         self,

--- a/synth_ai/research/factory_usage.py
+++ b/synth_ai/research/factory_usage.py
@@ -88,7 +88,9 @@ class FactoryUsageBudget:
             run_count=_optional_int(mapping, "run_count"),
             remaining_runs=_optional_int(mapping, "remaining_runs"),
             run_budget_scope=_optional_str(mapping, "run_budget_scope"),
-            run_budget_window_start=_optional_datetime(mapping, "run_budget_window_start"),
+            run_budget_window_start=_optional_datetime(
+                mapping, "run_budget_window_start"
+            ),
             limit_pico_usd=_optional_int(mapping, "limit_pico_usd"),
             used_pico_usd=_optional_int(mapping, "used_pico_usd"),
             remaining_pico_usd=_optional_int(mapping, "remaining_pico_usd"),
@@ -217,7 +219,8 @@ class FactoryEventsPage:
         return cls(
             factory_id=str(mapping.get("factory_id") or ""),
             events=tuple(
-                FactoryEvent.from_wire(item) for item in list(mapping.get("events") or [])
+                FactoryEvent.from_wire(item)
+                for item in list(mapping.get("events") or [])
             ),
             next_cursor=_optional_str(mapping, "next_cursor"),
             raw=dict(mapping),

--- a/synth_ai/research/factory_usage.py
+++ b/synth_ai/research/factory_usage.py
@@ -1,0 +1,279 @@
+"""Typed Factory usage and event bindings for ``client.research.factories``.
+
+Backend routes (backend PR #747):
+
+- ``GET /smr/factories/{factory_id}/usage`` → ``SmrFactoryUsageResponse``
+- ``GET /smr/factories/{factory_id}/events`` → ``SmrFactoryEventsResponse``
+
+Both are read via the session client's internal ``_request_json`` layer, the
+same transport every other ``/smr`` binding uses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from synth_ai.managed_research.models.factories import _optional_datetime
+from synth_ai.managed_research.sdk.client import ManagedResearchClient
+
+
+def _require_usage_mapping(payload: object, *, label: str) -> dict[str, object]:
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{label} payload must be an object")
+    return {str(key): value for key, value in payload.items()}
+
+
+def _optional_int(mapping: Mapping[str, object], key: str) -> int | None:
+    value = mapping.get(key)
+    return int(value) if value is not None else None  # type: ignore[arg-type]
+
+
+def _optional_float(mapping: Mapping[str, object], key: str) -> float | None:
+    value = mapping.get(key)
+    return float(value) if value is not None else None  # type: ignore[arg-type]
+
+
+def _optional_str(mapping: Mapping[str, object], key: str) -> str | None:
+    value = mapping.get(key)
+    return str(value) if value is not None else None
+
+
+@dataclass(frozen=True)
+class FactoryUsageCost:
+    """Typed ``SmrFactoryUsageCostTotals`` (nominal ledger cost for the window)."""
+
+    total_cents: int
+    total_pico_usd: int
+    total_usd: float
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> FactoryUsageCost:
+        mapping = _require_usage_mapping(payload, label="factory usage cost")
+        return cls(
+            total_cents=int(mapping.get("total_cents") or 0),
+            total_pico_usd=int(mapping.get("total_pico_usd") or 0),
+            total_usd=float(mapping.get("total_usd") or 0.0),
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class FactoryUsageBudget:
+    """Typed ``SmrFactoryUsageBudgetResponse`` (budget policy status; all optional)."""
+
+    run_limit: int | None = None
+    run_count: int | None = None
+    remaining_runs: int | None = None
+    run_budget_scope: str | None = None
+    run_budget_window_start: datetime | None = None
+    limit_pico_usd: int | None = None
+    used_pico_usd: int | None = None
+    remaining_pico_usd: int | None = None
+    limit_usd: float | None = None
+    used_usd: float | None = None
+    remaining_usd: float | None = None
+    period_start: datetime | None = None
+    period_end: datetime | None = None
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> FactoryUsageBudget:
+        mapping = _require_usage_mapping(payload, label="factory usage budget")
+        return cls(
+            run_limit=_optional_int(mapping, "run_limit"),
+            run_count=_optional_int(mapping, "run_count"),
+            remaining_runs=_optional_int(mapping, "remaining_runs"),
+            run_budget_scope=_optional_str(mapping, "run_budget_scope"),
+            run_budget_window_start=_optional_datetime(mapping, "run_budget_window_start"),
+            limit_pico_usd=_optional_int(mapping, "limit_pico_usd"),
+            used_pico_usd=_optional_int(mapping, "used_pico_usd"),
+            remaining_pico_usd=_optional_int(mapping, "remaining_pico_usd"),
+            limit_usd=_optional_float(mapping, "limit_usd"),
+            used_usd=_optional_float(mapping, "used_usd"),
+            remaining_usd=_optional_float(mapping, "remaining_usd"),
+            period_start=_optional_datetime(mapping, "period_start"),
+            period_end=_optional_datetime(mapping, "period_end"),
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class FactoryEffortUsage:
+    """Typed ``SmrFactoryEffortUsageResponse`` (per-effort drawdown in the window)."""
+
+    effort_id: str
+    name: str
+    cost_microcents: int
+    cost_cents: int
+    cost_usd: float
+    debit_count: int
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> FactoryEffortUsage:
+        mapping = _require_usage_mapping(payload, label="factory effort usage")
+        return cls(
+            effort_id=str(mapping.get("effort_id") or ""),
+            name=str(mapping.get("name") or ""),
+            cost_microcents=int(mapping.get("cost_microcents") or 0),
+            cost_cents=int(mapping.get("cost_cents") or 0),
+            cost_usd=float(mapping.get("cost_usd") or 0.0),
+            debit_count=int(mapping.get("debit_count") or 0),
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class FactoryUsage:
+    """Typed ``SmrFactoryUsageResponse``.
+
+    Backend route: ``GET /smr/factories/{factory_id}/usage``
+    (query ``window``: ``month_to_date`` | ``last_7_days``).
+    """
+
+    factory_id: str
+    org_id: str
+    window: str
+    window_start: datetime | None
+    window_end: datetime | None
+    cost: FactoryUsageCost
+    budget: FactoryUsageBudget | None = None
+    run_count: int = 0
+    effort_count: int = 0
+    by_effort: tuple[FactoryEffortUsage, ...] = ()
+    updated_at: datetime | None = None
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> FactoryUsage:
+        mapping = _require_usage_mapping(payload, label="factory usage")
+        budget = mapping.get("budget")
+        return cls(
+            factory_id=str(mapping.get("factory_id") or ""),
+            org_id=str(mapping.get("org_id") or ""),
+            window=str(mapping.get("window") or ""),
+            window_start=_optional_datetime(mapping, "window_start"),
+            window_end=_optional_datetime(mapping, "window_end"),
+            cost=FactoryUsageCost.from_wire(mapping.get("cost") or {}),
+            budget=FactoryUsageBudget.from_wire(budget) if budget is not None else None,
+            run_count=int(mapping.get("run_count") or 0),
+            effort_count=int(mapping.get("effort_count") or 0),
+            by_effort=tuple(
+                FactoryEffortUsage.from_wire(item)
+                for item in list(mapping.get("by_effort") or [])
+            ),
+            updated_at=_optional_datetime(mapping, "updated_at"),
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class FactoryEvent:
+    """Typed ``SmrFactoryEventResponse`` (one durable factory event row)."""
+
+    event_id: str
+    occurred_at: datetime | None
+    kind: str
+    source: str
+    payload: dict[str, object] = field(default_factory=dict)
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> FactoryEvent:
+        mapping = _require_usage_mapping(payload, label="factory event")
+        event_payload = mapping.get("payload")
+        return cls(
+            event_id=str(mapping.get("event_id") or ""),
+            occurred_at=_optional_datetime(mapping, "occurred_at"),
+            kind=str(mapping.get("kind") or ""),
+            source=str(mapping.get("source") or ""),
+            payload=_require_usage_mapping(event_payload, label="factory event payload")
+            if isinstance(event_payload, Mapping)
+            else {},
+            raw=dict(mapping),
+        )
+
+
+@dataclass(frozen=True)
+class FactoryEventsPage:
+    """Typed ``SmrFactoryEventsResponse`` (newest-first cursor page).
+
+    Backend route: ``GET /smr/factories/{factory_id}/events``
+    (query ``limit`` 1-500, ``cursor``; ``next_cursor`` is null when drained).
+    """
+
+    factory_id: str
+    events: tuple[FactoryEvent, ...] = ()
+    next_cursor: str | None = None
+    raw: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, payload: object) -> FactoryEventsPage:
+        mapping = _require_usage_mapping(payload, label="factory events page")
+        return cls(
+            factory_id=str(mapping.get("factory_id") or ""),
+            events=tuple(
+                FactoryEvent.from_wire(item) for item in list(mapping.get("events") or [])
+            ),
+            next_cursor=_optional_str(mapping, "next_cursor"),
+            raw=dict(mapping),
+        )
+
+
+def fetch_factory_usage(
+    session: ManagedResearchClient,
+    factory_id: str,
+    *,
+    window: str = "month_to_date",
+) -> FactoryUsage:
+    """Read the factory usage aggregate.
+
+    Backend route: ``GET /smr/factories/{factory_id}/usage`` (query ``window``).
+    """
+    payload = session._request_json(
+        "GET",
+        f"/smr/factories/{factory_id}/usage",
+        params={"window": str(window)},
+    )
+    return FactoryUsage.from_wire(payload)
+
+
+def fetch_factory_events(
+    session: ManagedResearchClient,
+    factory_id: str,
+    *,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> FactoryEventsPage:
+    """Read one page of the durable factory event projection.
+
+    Backend route: ``GET /smr/factories/{factory_id}/events``
+    (query ``limit``, ``cursor``).
+    """
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = int(limit)
+    if cursor is not None:
+        params["cursor"] = str(cursor)
+    payload = session._request_json(
+        "GET",
+        f"/smr/factories/{factory_id}/events",
+        params=params or None,
+    )
+    return FactoryEventsPage.from_wire(payload)
+
+
+__all__ = [
+    "FactoryEffortUsage",
+    "FactoryEvent",
+    "FactoryEventsPage",
+    "FactoryUsage",
+    "FactoryUsageBudget",
+    "FactoryUsageCost",
+    "fetch_factory_events",
+    "fetch_factory_usage",
+]

--- a/synth_ai/research/factory_usage.py
+++ b/synth_ai/research/factory_usage.py
@@ -88,9 +88,7 @@ class FactoryUsageBudget:
             run_count=_optional_int(mapping, "run_count"),
             remaining_runs=_optional_int(mapping, "remaining_runs"),
             run_budget_scope=_optional_str(mapping, "run_budget_scope"),
-            run_budget_window_start=_optional_datetime(
-                mapping, "run_budget_window_start"
-            ),
+            run_budget_window_start=_optional_datetime(mapping, "run_budget_window_start"),
             limit_pico_usd=_optional_int(mapping, "limit_pico_usd"),
             used_pico_usd=_optional_int(mapping, "used_pico_usd"),
             remaining_pico_usd=_optional_int(mapping, "remaining_pico_usd"),
@@ -165,8 +163,7 @@ class FactoryUsage:
             run_count=int(mapping.get("run_count") or 0),
             effort_count=int(mapping.get("effort_count") or 0),
             by_effort=tuple(
-                FactoryEffortUsage.from_wire(item)
-                for item in list(mapping.get("by_effort") or [])
+                FactoryEffortUsage.from_wire(item) for item in list(mapping.get("by_effort") or [])
             ),
             updated_at=_optional_datetime(mapping, "updated_at"),
             raw=dict(mapping),
@@ -219,8 +216,7 @@ class FactoryEventsPage:
         return cls(
             factory_id=str(mapping.get("factory_id") or ""),
             events=tuple(
-                FactoryEvent.from_wire(item)
-                for item in list(mapping.get("events") or [])
+                FactoryEvent.from_wire(item) for item in list(mapping.get("events") or [])
             ),
             next_cursor=_optional_str(mapping, "next_cursor"),
             raw=dict(mapping),

--- a/tests/research/test_post747_bindings.py
+++ b/tests/research/test_post747_bindings.py
@@ -1,0 +1,352 @@
+"""Post-747 bindings tests: fake sessions only, no network.
+
+Covers factory usage/events, account readiness, and the trigger_result
+launch-request regression.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from synth_ai.managed_research.models.run_launch import RunLaunchRequest, RunLaunchResult
+from synth_ai.managed_research.sdk.client import ManagedResearchClient
+from synth_ai.managed_research.sdk.runs import RunsAPI
+from synth_ai.research.account import AccountReadiness, ResearchAccountAPI
+from synth_ai.research.factories import ResearchFactoriesAPI
+from synth_ai.research.factory_usage import (
+    FactoryEventsPage,
+    FactoryUsage,
+)
+
+
+class _RecordingSession:
+    """Fake session client capturing every ``_request_json`` call."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._responses = responses or {}
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        allow_not_found: bool = False,
+    ) -> Any:
+        self.calls.append(
+            {
+                "method": method,
+                "path": path,
+                "params": params,
+                "json_body": json_body,
+            }
+        )
+        return self._responses.get(f"{method} {path}", {})
+
+
+def _sample_usage_payload() -> dict[str, Any]:
+    return {
+        "factory_id": "fac_1",
+        "org_id": "org_1",
+        "window": "month_to_date",
+        "window_start": "2026-07-01T00:00:00Z",
+        "window_end": "2026-07-20T00:00:00Z",
+        "cost": {"total_cents": 1234, "total_pico_usd": 12340000000000, "total_usd": 12.34},
+        "budget": {
+            "run_limit": 10,
+            "run_count": 4,
+            "remaining_runs": 6,
+            "limit_usd": 100.0,
+            "used_usd": 12.34,
+            "remaining_usd": 87.66,
+        },
+        "run_count": 4,
+        "effort_count": 2,
+        "by_effort": [
+            {
+                "effort_id": "eff_1",
+                "name": "Effort One",
+                "cost_microcents": 123400,
+                "cost_cents": 1,
+                "cost_usd": 0.01234,
+                "debit_count": 3,
+            }
+        ],
+        "updated_at": "2026-07-20T12:00:00Z",
+        "brand_new_backend_key": True,
+    }
+
+
+def test_factory_usage_path_and_decode() -> None:
+    session = _RecordingSession(
+        responses={"GET /smr/factories/fac_1/usage": _sample_usage_payload()}
+    )
+    api = ResearchFactoriesAPI(session)  # type: ignore[arg-type]
+
+    usage = api.usage("fac_1", window="last_7_days")
+    assert isinstance(usage, FactoryUsage)
+    assert usage.factory_id == "fac_1"
+    assert usage.org_id == "org_1"
+    assert usage.window == "month_to_date"
+    assert usage.window_start is not None
+    assert usage.cost.total_cents == 1234
+    assert usage.cost.total_pico_usd == 12340000000000
+    assert usage.cost.total_usd == 12.34
+    assert usage.budget is not None
+    assert usage.budget.run_limit == 10
+    assert usage.budget.remaining_usd == 87.66
+    assert usage.run_count == 4
+    assert usage.effort_count == 2
+    assert usage.by_effort[0].effort_id == "eff_1"
+    assert usage.by_effort[0].debit_count == 3
+    assert usage.updated_at is not None
+    assert usage.raw["brand_new_backend_key"] is True
+
+    assert session.calls == [
+        {
+            "method": "GET",
+            "path": "/smr/factories/fac_1/usage",
+            "params": {"window": "last_7_days"},
+            "json_body": None,
+        }
+    ]
+
+
+def test_factory_usage_null_budget() -> None:
+    payload = _sample_usage_payload()
+    payload["budget"] = None
+    usage = FactoryUsage.from_wire(payload)
+    assert usage.budget is None
+
+
+def test_factory_events_path_and_decode() -> None:
+    session = _RecordingSession(
+        responses={
+            "GET /smr/factories/fac_1/events": {
+                "factory_id": "fac_1",
+                "events": [
+                    {
+                        "event_id": "evt_1",
+                        "occurred_at": "2026-07-20T11:00:00Z",
+                        "kind": "champion_selected",
+                        "source": "champion_event",
+                        "payload": {"candidate_id": "cand_1"},
+                    }
+                ],
+                "next_cursor": "cur_2",
+            }
+        }
+    )
+    api = ResearchFactoriesAPI(session)  # type: ignore[arg-type]
+
+    page = api.events("fac_1", limit=25, cursor="cur_1")
+    assert isinstance(page, FactoryEventsPage)
+    assert page.factory_id == "fac_1"
+    assert page.next_cursor == "cur_2"
+    assert page.events[0].event_id == "evt_1"
+    assert page.events[0].kind == "champion_selected"
+    assert page.events[0].source == "champion_event"
+    assert page.events[0].payload == {"candidate_id": "cand_1"}
+    assert page.events[0].occurred_at is not None
+
+    assert session.calls == [
+        {
+            "method": "GET",
+            "path": "/smr/factories/fac_1/events",
+            "params": {"limit": 25, "cursor": "cur_1"},
+            "json_body": None,
+        }
+    ]
+
+
+def test_factory_events_default_params_omitted() -> None:
+    session = _RecordingSession(
+        responses={"GET /smr/factories/fac_1/events": {"factory_id": "fac_1", "events": []}}
+    )
+    api = ResearchFactoriesAPI(session)  # type: ignore[arg-type]
+    page = api.events("fac_1")
+    assert page.events == ()
+    assert page.next_cursor is None
+    assert session.calls[0]["params"] is None
+
+
+class _PagingSession:
+    """Fake session serving a fixed cursor sequence, including a repeat."""
+
+    def __init__(self, pages: dict[str | None, dict[str, Any]]) -> None:
+        self.cursors_seen: list[str | None] = []
+        self._pages = pages
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        allow_not_found: bool = False,
+    ) -> Any:
+        cursor = (params or {}).get("cursor")
+        self.cursors_seen.append(cursor)
+        return self._pages[cursor]
+
+
+def _event(event_id: str) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "occurred_at": "2026-07-20T11:00:00Z",
+        "kind": "k",
+        "source": "project_event",
+        "payload": {},
+    }
+
+
+def test_iter_events_pages_until_cursor_drains() -> None:
+    session = _PagingSession(
+        {
+            None: {"factory_id": "fac_1", "events": [_event("e1")], "next_cursor": "c1"},
+            "c1": {"factory_id": "fac_1", "events": [_event("e2")], "next_cursor": "c2"},
+            "c2": {"factory_id": "fac_1", "events": [_event("e3")], "next_cursor": None},
+        }
+    )
+    api = ResearchFactoriesAPI(session)  # type: ignore[arg-type]
+    ids = [event.event_id for event in api.iter_events("fac_1")]
+    assert ids == ["e1", "e2", "e3"]
+    assert session.cursors_seen == [None, "c1", "c2"]
+
+
+def test_iter_events_stops_on_repeated_cursor() -> None:
+    session = _PagingSession(
+        {
+            None: {"factory_id": "fac_1", "events": [_event("e1")], "next_cursor": "c1"},
+            "c1": {"factory_id": "fac_1", "events": [_event("e2")], "next_cursor": "c1"},
+        }
+    )
+    api = ResearchFactoriesAPI(session)  # type: ignore[arg-type]
+    ids = [event.event_id for event in api.iter_events("fac_1")]
+    assert ids == ["e1", "e2"]
+    assert session.cursors_seen == [None, "c1"]
+
+
+def test_factory_handle_usage_and_events_paths() -> None:
+    session = _RecordingSession(
+        responses={
+            "GET /smr/factories/fac_1/usage": _sample_usage_payload(),
+            "GET /smr/factories/fac_1/events": {"factory_id": "fac_1", "events": []},
+        }
+    )
+    api = ResearchFactoriesAPI(session)  # type: ignore[arg-type]
+    handle = api.open("fac_1")
+
+    usage = handle.usage(window="month_to_date")
+    assert usage.factory_id == "fac_1"
+    page = handle.events(limit=5)
+    assert page.factory_id == "fac_1"
+
+    observed = [(call["method"], call["path"]) for call in session.calls]
+    assert observed == [
+        ("GET", "/smr/factories/fac_1/usage"),
+        ("GET", "/smr/factories/fac_1/events"),
+    ]
+    assert session.calls[0]["params"] == {"window": "month_to_date"}
+    assert session.calls[1]["params"] == {"limit": 5}
+
+
+def test_account_readiness_path_and_decode() -> None:
+    session = _RecordingSession(
+        responses={
+            "GET /api/v1/account/readiness": {
+                "ready": False,
+                "checks": [
+                    {
+                        "id": "balance_positive",
+                        "ok": False,
+                        "label": "Credit balance is positive",
+                        "cta": {"label": "Add credits", "href": "/settings/billing"},
+                        "metadata": {"balance_cents": 0, "balance_dollars": 0.0},
+                    },
+                    {
+                        "id": "byok_valid",
+                        "ok": True,
+                        "label": "Provider keys stored",
+                        "cta": None,
+                        "metadata": {},
+                    },
+                ],
+            }
+        }
+    )
+    account = ResearchAccountAPI(session)  # type: ignore[arg-type]
+
+    readiness = account.readiness()
+    assert isinstance(readiness, AccountReadiness)
+    assert readiness.ready is False
+    assert len(readiness.checks) == 2
+    first = readiness.checks[0]
+    assert first.id == "balance_positive"
+    assert first.ok is False
+    assert first.cta is not None
+    assert first.cta.label == "Add credits"
+    assert first.cta.href == "/settings/billing"
+    assert first.metadata["balance_cents"] == 0
+    second = readiness.checks[1]
+    assert second.ok is True
+    assert second.cta is None
+
+    assert session.calls == [
+        {
+            "method": "GET",
+            "path": "/api/v1/account/readiness",
+            "params": None,
+            "json_body": None,
+        }
+    ]
+
+
+class _FakeLaunchClient:
+    """Fake client using the real ``trigger_run_result`` over a recording ``trigger_run``."""
+
+    trigger_run_result = ManagedResearchClient.trigger_run_result
+
+    def __init__(self) -> None:
+        self.trigger_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def trigger_run(self, project_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.trigger_calls.append((project_id, kwargs))
+        return {"run_id": "run_1"}
+
+
+def test_trigger_run_result_expands_launch_request() -> None:
+    """Regression: trigger_run has no ``request`` kwarg; the request must be expanded."""
+    client = _FakeLaunchClient()
+    request = RunLaunchRequest(runbook_preset="smoke", timebox_seconds=60)
+
+    result = client.trigger_run_result("proj_1", request=request)
+
+    assert isinstance(result, RunLaunchResult)
+    assert result.project_id == "proj_1"
+    assert result.run_id == "run_1"
+    assert len(client.trigger_calls) == 1
+    project_id, kwargs = client.trigger_calls[0]
+    assert project_id == "proj_1"
+    assert "request" not in kwargs
+    assert kwargs["runbook_preset"] == "smoke"
+    assert kwargs["timebox_seconds"] == 60
+
+
+def test_runs_api_trigger_result_uses_expanded_request() -> None:
+    client = _FakeLaunchClient()
+    api = RunsAPI(client)  # type: ignore[arg-type]
+    request = RunLaunchRequest(runbook_preset="smoke", timebox_seconds=30)
+
+    result = api.trigger_result("proj_1", request=request)
+
+    assert result.run_id == "run_1"
+    project_id, kwargs = client.trigger_calls[0]
+    assert project_id == "proj_1"
+    assert "request" not in kwargs
+    assert kwargs["timebox_seconds"] == 30


### PR DESCRIPTION
SDK bindings for the three endpoints merged in backend PR #747, plus one bugfix.

## Bindings
- `research.factories.usage(factory_id, *, window="month_to_date") -> FactoryUsage` — `GET /smr/factories/{factory_id}/usage` (window: `month_to_date` | `last_7_days`). Typed cost totals, nullable budget, per-effort drawdown.
- `research.factories.events(factory_id, *, limit=None, cursor=None) -> FactoryEventsPage` — `GET /smr/factories/{factory_id}/events`. Typed event rows + `next_cursor`.
- `research.factories.iter_events(factory_id, *, limit=None)` — generator that pages until `next_cursor` is null or repeats (bounded, no sleeps).
- `ResearchFactoryHandle.usage(window=...)` / `.events(limit=..., cursor=...)` on the existing handle.
- `research.account.readiness() -> AccountReadiness` — `GET /api/v1/account/readiness`. Typed checks with CTA (label/href) and metadata.

New models live in `synth_ai/research/factory_usage.py` and `synth_ai/research/account.py`, following the facade pattern (frozen dataclasses, `from_wire`, `raw` passthrough, `_request_json` transport).

## Bugfix
`ManagedResearchClient.trigger_run_result` called `self.trigger_run(project_id, request=request)`, but `trigger_run` has no `request` parameter — TypeError on every call (this is the call site under `RunsAPI.trigger_result`). It now expands `request.to_client_kwargs()`. Regression tests cover both the client method and `RunsAPI.trigger_result` via a fake client.

## Tests
- `tests/research/test_post747_bindings.py`: fake sessions only, no network — path/param construction, typed decode from sample wire dicts (including null budget, unknown-key passthrough, cursor pagination + repeat-cursor stop), and the trigger_result regression.
- `uv run ruff check` clean; `uv run pytest tests/ -q` — 70 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)