### PR TITLE
fix: map backend billing blocker codes to ResearchInsufficientCreditsError

### DIFF
--- a/synth_ai/managed_research/transport/http.py
+++ b/synth_ai/managed_research/transport/http.py
@@ -28,6 +28,37 @@ from synth_ai.managed_research.errors import (
 )
 from synth_ai.managed_research.transport.streaming import SseEvent, iter_sse_events
 
+# Backend billing-admission blocker codes for the wallet/allowance family
+# (services/smr/billing/preflight.py + admission.py). These arrive as HTTP 402
+# ``{"detail": {"error_code": ..., "billing_preflight": ...}}`` bodies and mean
+# the org cannot fund the request — the SDK's insufficient-credits condition.
+# ``factory_*`` budget codes are deliberately excluded: factory budget
+# exhaustion is a policy denial on the Factory effort, not an org credit state,
+# and stays a structured denial.
+_INSUFFICIENT_CREDITS_CODES = frozenset(
+    {
+        "smr_insufficient_credits",
+        "smr_allowance_and_wallet_insufficient",
+        "smr_allowance_and_wallet_exhausted",
+        "smr_wallet_exhausted",
+        "smr_allowance_manual_reset_required",
+        "smr_billing_blocked",
+    }
+)
+# Backend emits per-model-class / per-window variants (e.g.
+# ``smr_allowance_unprovisioned_premium``); its own blocker classifier
+# (admission.py::is_billing_admission_blocker) matches these prefixes.
+_INSUFFICIENT_CREDITS_CODE_PREFIXES = (
+    "smr_allowance_unprovisioned_",
+    "smr_window_exhausted_",
+)
+
+
+def _is_insufficient_credits_code(code: str) -> bool:
+    if code in _INSUFFICIENT_CREDITS_CODES:
+        return True
+    return code.startswith(_INSUFFICIENT_CREDITS_CODE_PREFIXES)
+
 
 def _error_message(response: httpx.Response) -> str:
     try:
@@ -133,7 +164,7 @@ def _raise_for_error_response(response: httpx.Response) -> None:
                         response_text=response_text,
                         detail=detail,
                     )
-                if stripped == "smr_insufficient_credits":
+                if _is_insufficient_credits_code(stripped):
                     raise SmrInsufficientCreditsError(
                         message,
                         status_code=status_code,

--- a/tests/managed_research/test_transport_error_mapping.py
+++ b/tests/managed_research/test_transport_error_mapping.py
@@ -1,0 +1,133 @@
+"""Transport error mapping: backend 402 billing blocker codes -> typed SDK errors.
+
+The backend never emits ``smr_insufficient_credits`` from the billing admission
+gate; real credit denials carry the wallet/allowance ledger blocker codes built
+by ``services/smr/billing/admission.py::billing_blocker_detail``. These tests
+pin the SDK-side mapping of that family to ``SmrInsufficientCreditsError``
+(aliased publicly as ``ResearchInsufficientCreditsError``) and prove that
+factory budget codes and unknown codes remain ``SmrStructuredDenialError``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from synth_ai.managed_research.errors import (
+    SmrConcurrentRunLimitExceededError,
+    SmrInsufficientCreditsError,
+    SmrStructuredDenialError,
+)
+from synth_ai.managed_research.transport.http import _raise_for_error_response
+from synth_ai.research.errors import ResearchInsufficientCreditsError
+
+
+def _billing_blocker_detail(error_code: str) -> dict[str, Any]:
+    """Mirror of backend billing_blocker_detail (admission.py:184-205)."""
+    return {
+        "error_code": error_code,
+        "message": (
+            "SMR usage is exhausted for this organization. Wait for the next "
+            "owner-approved allowance reset, top up flex credits, upgrade the "
+            "plan, or ask an admin for a manual grant."
+        ),
+        "billing_preflight": {
+            "org_id": "org_123",
+            "surface": "run",
+            "project_id": "proj_456",
+            "run_id": None,
+            "factory_effort_id": None,
+            "dev_environment_id": None,
+            "model_class": "premium",
+            "estimated_customer_debit_microcents": 500_000_000,
+            "allowed": False,
+            "blocked_reason": error_code,
+            "debit_pool_order": ["five_hour", "weekly", "wallet"],
+            "selected_debit_pool": None,
+            "available_microcents": 0,
+            "wallet_balance_microcents": 0,
+            "generated_at": "2026-07-20T12:00:00+00:00",
+            "factory_run_admission": None,
+        },
+        "retryable": False,
+    }
+
+
+def _response(status_code: int, detail: dict[str, Any]) -> httpx.Response:
+    request = httpx.Request("POST", "https://backend.example/api/smr/runs")
+    return httpx.Response(
+        status_code,
+        request=request,
+        content=json.dumps({"detail": detail}).encode(),
+        headers={"content-type": "application/json"},
+    )
+
+
+INSUFFICIENT_CREDITS_CODES = [
+    "smr_insufficient_credits",
+    "smr_allowance_and_wallet_insufficient",
+    "smr_allowance_and_wallet_exhausted",
+    "smr_wallet_exhausted",
+    "smr_allowance_manual_reset_required",
+    "smr_billing_blocked",
+    "smr_allowance_unprovisioned_premium",
+    "smr_allowance_unprovisioned_value",
+    "smr_window_exhausted_five_hour",
+]
+
+
+@pytest.mark.parametrize("code", INSUFFICIENT_CREDITS_CODES)
+def test_wallet_allowance_402_codes_raise_insufficient_credits(code: str) -> None:
+    detail = _billing_blocker_detail(code)
+    response = _response(402, detail)
+    with pytest.raises(SmrInsufficientCreditsError) as excinfo:
+        _raise_for_error_response(response)
+    exc = excinfo.value
+    assert exc.status_code == 402
+    assert exc.detail == detail
+    assert exc.detail["billing_preflight"]["blocked_reason"] == code
+    assert exc.detail["error_code"] == code
+    assert "exhausted" in str(exc)
+
+
+def test_public_alias_catches_mapped_402() -> None:
+    response = _response(402, _billing_blocker_detail("smr_wallet_exhausted"))
+    with pytest.raises(ResearchInsufficientCreditsError):
+        _raise_for_error_response(response)
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["factory_budget_exhausted", "factory_run_budget_exhausted"],
+)
+def test_factory_budget_402_codes_stay_structured_denials(code: str) -> None:
+    detail = _billing_blocker_detail(code)
+    response = _response(402, detail)
+    with pytest.raises(SmrStructuredDenialError) as excinfo:
+        _raise_for_error_response(response)
+    exc = excinfo.value
+    assert not isinstance(exc, SmrInsufficientCreditsError)
+    assert exc.status_code == 402
+    assert exc.detail == detail
+
+
+def test_unmapped_code_stays_structured_denial() -> None:
+    detail = {"error_code": "smr_some_future_code", "message": "denied"}
+    response = _response(403, detail)
+    with pytest.raises(SmrStructuredDenialError) as excinfo:
+        _raise_for_error_response(response)
+    exc = excinfo.value
+    assert not isinstance(exc, SmrInsufficientCreditsError)
+    assert exc.status_code == 403
+    assert exc.detail == detail
+
+
+def test_concurrent_run_limit_429_mapping_unchanged() -> None:
+    detail = {"error_code": "smr_concurrent_run_limit_exceeded", "message": "too many"}
+    response = _response(429, detail)
+    with pytest.raises(SmrConcurrentRunLimitExceededError) as excinfo:
+        _raise_for_error_response(response)
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.detail == detail


### PR DESCRIPTION
## Problem

Launch-verification item #2: `ResearchInsufficientCreditsError` / `SmrInsufficientCreditsError` never fires. The transport dispatches on `smr_insufficient_credits`, but the backend's billing admission gate never emits that code — real 402 credit denials carry the wallet/allowance ledger blocker codes built by `services/smr/billing/preflight.py:200-207` and `admission.py::billing_blocker_detail`. Callers therefore get the generic `SmrStructuredDenialError`, and launch docs cannot say "catch ResearchInsufficientCreditsError".

## Fix (SDK-side by design)

This resolves the dead-code mismatch on the SDK side. The backend alternative — changing the emitted codes to `smr_insufficient_credits` — was rejected because other consumers dispatch on the existing ledger codes (e.g. `is_billing_admission_blocker`); changing emission would break them.

`synth_ai/managed_research/transport/http.py` now raises `SmrInsufficientCreditsError` (public alias `ResearchInsufficientCreditsError`) for the wallet/allowance insufficient-funds family, preserving `status_code` and the full `detail` payload exactly like the existing mappings:

| error_code | SDK exception |
| --- | --- |
| `smr_insufficient_credits` (kept, future-proof) | `SmrInsufficientCreditsError` |
| `smr_allowance_and_wallet_insufficient` | `SmrInsufficientCreditsError` |
| `smr_allowance_and_wallet_exhausted` | `SmrInsufficientCreditsError` |
| `smr_wallet_exhausted` | `SmrInsufficientCreditsError` |
| `smr_allowance_manual_reset_required` | `SmrInsufficientCreditsError` |
| `smr_billing_blocked` | `SmrInsufficientCreditsError` |
| `smr_allowance_unprovisioned_*` (prefix: `_premium`, `_value`) | `SmrInsufficientCreditsError` |
| `smr_window_exhausted_*` (prefix) | `SmrInsufficientCreditsError` |
| `factory_budget_exhausted`, `factory_run_budget_exhausted` | `SmrStructuredDenialError` (unchanged) |
| any other structured code | unchanged behavior |

The prefix families mirror the backend's own classifier (`admission.py::is_billing_admission_blocker`). Factory budget codes stay structured denials: factory budget exhaustion is a Factory effort policy denial, not an org credit state, and no typed `FactoryBudgetExhausted` class exists in the public surface — none is invented here.

## Tests

New `tests/managed_research/test_transport_error_mapping.py`: one case per mapped code decoding a realistic 402 body (copied from the backend `billing_blocker_detail` shape) asserting class + `status_code` + `detail`; factory codes and an unmapped code proven to remain `SmrStructuredDenialError`; the 429 `smr_concurrent_run_limit_exceeded` mapping pinned unchanged. `uv run pytest tests/ -q`: 84 passed. Changed files ruff-clean.

## Release note

`release/0.16.0-prep-20260720` (#303) is still unmerged — if this merges after #303's prep, a cherry-pick of this commit onto the release branch is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)