### PR TITLE
fix(managed-research): seal provider keys client-side

### DIFF
--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 import httpx
 
+from synth_ai.managed_research._internal.crypto import encrypt_for_backend
 from synth_ai.managed_research.errors import (
     SmrApiError,
     SmrHostedModelOverridesError,
@@ -5270,12 +5271,33 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
             funding_source,
             field_name="funding_source",
         )
+        if api_key and api_key.strip() and encrypted_key_b64 and encrypted_key_b64.strip():
+            raise ValueError("set_provider_key accepts api_key or encrypted_key_b64, not both")
         payload: dict[str, Any] = {
             "provider": normalized_provider.value,
             "funding_source": normalized_funding_source.value,
         }
         if api_key and api_key.strip():
-            payload["api_key"] = api_key.strip()
+            public_key_response = _coerce_dict(
+                self._request_json("GET", "/api/v1/crypto/public-key"),
+                label="backend crypto public key",
+            )
+            algorithm = _require_non_empty_string(
+                public_key_response.get("alg"),
+                field_name="backend crypto public key alg",
+            )
+            if algorithm != "libsodium.sealedbox.v1":
+                raise ValueError(
+                    f"unsupported backend provider-key encryption algorithm: {algorithm}"
+                )
+            public_key_b64 = _require_non_empty_string(
+                public_key_response.get("public_key"),
+                field_name="backend crypto public key",
+            )
+            payload["encrypted_key_b64"] = encrypt_for_backend(
+                public_key_b64,
+                api_key.strip(),
+            )
         if encrypted_key_b64 and encrypted_key_b64.strip():
             payload["encrypted_key_b64"] = encrypted_key_b64.strip()
         if "api_key" not in payload and "encrypted_key_b64" not in payload:

--- a/tests/managed_research/test_provider_key_sealing.py
+++ b/tests/managed_research/test_provider_key_sealing.py
@@ -1,0 +1,109 @@
+"""Provider-key uploads seal plaintext locally before crossing the API boundary."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+from nacl.public import PrivateKey, SealedBox
+from synth_ai.managed_research.sdk.client import ManagedResearchClient
+
+
+def _client() -> ManagedResearchClient:
+    return ManagedResearchClient(
+        api_key="sk-test",
+        backend_base="https://api.example.test",
+    )
+
+
+def test_set_provider_key_seals_plaintext_before_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_key = PrivateKey.generate()
+    public_key_b64 = base64.b64encode(bytes(private_key.public_key)).decode("ascii")
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+    client = _client()
+
+    def _request_json(
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        calls.append((method, path, json_body))
+        if method == "GET":
+            return {
+                "alg": "libsodium.sealedbox.v1",
+                "public_key": public_key_b64,
+            }
+        return {"provider": "openai", "configured": True}
+
+    monkeypatch.setattr(client, "_request_json", _request_json)
+    try:
+        client.set_provider_key(
+            "project-1",
+            provider="openai",
+            api_key="provider-secret",
+        )
+    finally:
+        client.close()
+
+    assert calls[0][:2] == ("GET", "/api/v1/crypto/public-key")
+    assert calls[1][:2] == ("POST", "/smr/projects/project-1/provider_keys")
+    posted = calls[1][2]
+    assert posted is not None
+    assert "api_key" not in posted
+    ciphertext = base64.b64decode(posted["encrypted_key_b64"])
+    plaintext = SealedBox(private_key).decrypt(ciphertext).decode("utf-8")
+    assert plaintext == "provider-secret"
+
+
+def test_set_provider_key_rejects_unsupported_algorithm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[tuple[str, str]] = []
+
+    def _request_json(method: str, path: str, **_kwargs: Any) -> dict[str, str]:
+        calls.append((method, path))
+        return {"alg": "rsa.v1", "public_key": "unused"}
+
+    monkeypatch.setattr(client, "_request_json", _request_json)
+    try:
+        with pytest.raises(ValueError, match="unsupported backend provider-key"):
+            client.set_provider_key(
+                "project-1",
+                provider="openai",
+                api_key="provider-secret",
+            )
+    finally:
+        client.close()
+
+    assert calls == [("GET", "/api/v1/crypto/public-key")]
+
+
+def test_set_provider_key_rejects_plaintext_and_ciphertext_together(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[tuple[str, str]] = []
+
+    def _request_json(method: str, path: str, **_kwargs: Any) -> dict[str, str]:
+        calls.append((method, path))
+        return {}
+
+    monkeypatch.setattr(client, "_request_json", _request_json)
+    try:
+        with pytest.raises(ValueError, match="api_key or encrypted_key_b64"):
+            client.set_provider_key(
+                "project-1",
+                provider="openai",
+                api_key="provider-secret",
+                encrypted_key_b64="ciphertext",
+            )
+    finally:
+        client.close()
+
+    assert calls == []


### PR DESCRIPTION
## Summary

- Makes ManagedResearchClient.set_provider_key(api_key=...) fetch the backend sealed-box public key and send only encrypted_key_b64.
- Requires the exact libsodium.sealedbox.v1 algorithm and fails loudly without a plaintext fallback.
- Rejects ambiguous calls that provide both plaintext and pre-encrypted key material.
- Contains no transport error-mapping changes; #304 remains the sole owner of transport/http.py and should merge first.

## Validation

- uv run pytest tests/ -q: 73 passed, 1 unrelated deprecation warning.
- uv run ruff check synth_ai/managed_research/sdk/client.py tests/managed_research/test_provider_key_sealing.py: passed.
- The new test decrypts the captured POST ciphertext and proves the raw API key never enters the HTTP payload.
- git diff --check: passed.

This closes launch-verification item #12. If merged before 0.16.0 publishes, cherry-pick the merge commit onto release/0.16.0-prep-20260720 after #304 and add the corresponding changelog line.