### PR TITLE
fix(sdk): retire managed-agents proxy transports

### DIFF
--- a/synth_ai/client.py
+++ b/synth_ai/client.py
@@ -53,10 +53,6 @@ class SynthClient:
         api_key: str | None = None,
         base_url: str | None = None,
         timeout: float = 30.0,
-        openai_transport_mode: str = "auto",
-        openai_organization: str | None = None,
-        openai_project: str | None = None,
-        openai_request_id: str | None = None,
     ) -> None:
         self.api_key = _resolve_api_key(api_key)
         self.base_url = _resolve_base_url(base_url)
@@ -76,19 +72,8 @@ class SynthClient:
             backend_base=self.base_url,
             timeout=self.timeout,
         )
-        self.openai_agents_sdk = OpenAIAgentsSdkClient(
-            api_key=self.api_key,
-            backend_base=self.base_url,
-            timeout=self.timeout,
-            transport_mode=openai_transport_mode,
-            openai_organization=openai_organization,
-            openai_project=openai_project,
-            request_id=openai_request_id,
-        )
         self._research_client: ResearchClient | None = None
         self._horizons_private: HorizonsPrivateClient | None = None
-        self._managed_agents: ManagedAgentsAnthropicClient | None = None
-        self._managed_agents_anthropic: SynthManagedAgents | None = None
 
     def __getattr__(self, name: str) -> Any:
         if name == "horizons_private":
@@ -101,33 +86,23 @@ class SynthClient:
                 self._horizons_private = HorizonsPrivateClient(self.pools)
             return self._horizons_private
         if name == "managed_agents":
-            warnings.warn(
-                "SynthClient.managed_agents is deprecated; import ManagedAgentsAnthropicClient explicitly.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise AttributeError(
+                "SynthClient.managed_agents was retired with the backend managed-agents "
+                "proxy. Use ManagedAgentsAnthropicClient.from_horizons_private() only "
+                "with an explicit Horizons Private base URL and credential."
             )
-            if self._managed_agents is None:
-                self._managed_agents = ManagedAgentsAnthropicClient(
-                    api_key=self.api_key,
-                    backend_base=self.base_url,
-                    timeout=self.timeout,
-                )
-            return self._managed_agents
         if name == "managed_agents_anthropic":
-            warnings.warn(
-                "SynthClient.managed_agents_anthropic is deprecated; import SynthManagedAgents explicitly.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise AttributeError(
+                "SynthClient.managed_agents_anthropic was retired with the backend "
+                "managed-agents proxy. Use SynthManagedAgents.from_horizons_private() "
+                "only with an explicit Horizons Private base URL and credential."
             )
-            if self._managed_agents_anthropic is None:
-                self._managed_agents_anthropic = SynthManagedAgents.from_transport(
-                    ManagedAgentsAnthropicClient(
-                        api_key=self.api_key,
-                        backend_base=self.base_url,
-                        timeout=self.timeout,
-                    )
-                )
-            return self._managed_agents_anthropic
+        if name == "openai_agents_sdk":
+            raise AttributeError(
+                "SynthClient.openai_agents_sdk was retired with the backend managed-agents "
+                "proxy. Use OpenAIAgentsSdkClient.from_horizons_private() only with an "
+                "explicit Horizons Private base URL and credential."
+            )
         raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
 
     @property
@@ -153,10 +128,6 @@ class AsyncSynthClient:
         api_key: str | None = None,
         base_url: str | None = None,
         timeout: float = 30.0,
-        openai_transport_mode: str = "auto",
-        openai_organization: str | None = None,
-        openai_project: str | None = None,
-        openai_request_id: str | None = None,
     ) -> None:
         self.api_key = _resolve_api_key(api_key)
         self.base_url = _resolve_base_url(base_url)
@@ -181,22 +152,9 @@ class AsyncSynthClient:
             )
         )
         self._pools_sync = self.pools._sync_obj
-        self.openai_agents_sdk = AsyncOpenAIAgentsSdkClient(
-            OpenAIAgentsSdkClient(
-                api_key=self.api_key,
-                backend_base=self.base_url,
-                timeout=self.timeout,
-                transport_mode=openai_transport_mode,
-                openai_organization=openai_organization,
-                openai_project=openai_project,
-                request_id=openai_request_id,
-            )
-        )
         self._research_client: ResearchClient | None = None
         self._async_research_client: AsyncResearchClient | None = None
         self._horizons_private: AsyncHorizonsPrivateClient | None = None
-        self._managed_agents: AsyncManagedAgentsAnthropicClient | None = None
-        self._managed_agents_anthropic: AsyncSynthManagedAgents | None = None
 
     def __getattr__(self, name: str) -> Any:
         if name == "horizons_private":
@@ -211,35 +169,25 @@ class AsyncSynthClient:
                 )
             return self._horizons_private
         if name == "managed_agents":
-            warnings.warn(
-                "AsyncSynthClient.managed_agents is deprecated; import AsyncManagedAgentsAnthropicClient explicitly.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise AttributeError(
+                "AsyncSynthClient.managed_agents was retired with the backend managed-agents "
+                "proxy. Build AsyncManagedAgentsAnthropicClient around "
+                "ManagedAgentsAnthropicClient.from_horizons_private() with an explicit "
+                "Horizons Private base URL and credential."
             )
-            if self._managed_agents is None:
-                self._managed_agents = AsyncManagedAgentsAnthropicClient(
-                    ManagedAgentsAnthropicClient(
-                        api_key=self.api_key,
-                        backend_base=self.base_url,
-                        timeout=self.timeout,
-                    )
-                )
-            return self._managed_agents
         if name == "managed_agents_anthropic":
-            warnings.warn(
-                "AsyncSynthClient.managed_agents_anthropic is deprecated; import AsyncSynthManagedAgents explicitly.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise AttributeError(
+                "AsyncSynthClient.managed_agents_anthropic was retired with the backend "
+                "managed-agents proxy. Use AsyncSynthManagedAgents.from_horizons_private() "
+                "only with an explicit Horizons Private base URL and credential."
             )
-            if self._managed_agents_anthropic is None:
-                self._managed_agents_anthropic = AsyncSynthManagedAgents.from_transport(
-                    ManagedAgentsAnthropicClient(
-                        api_key=self.api_key,
-                        backend_base=self.base_url,
-                        timeout=self.timeout,
-                    )
-                )
-            return self._managed_agents_anthropic
+        if name == "openai_agents_sdk":
+            raise AttributeError(
+                "AsyncSynthClient.openai_agents_sdk was retired with the backend "
+                "managed-agents proxy. Build AsyncOpenAIAgentsSdkClient around "
+                "OpenAIAgentsSdkClient.from_horizons_private() with an explicit Horizons "
+                "Private base URL and credential."
+            )
         raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
 
     @property

--- a/synth_ai/managed_research/sdk/client.py
+++ b/synth_ai/managed_research/sdk/client.py
@@ -6154,7 +6154,7 @@ class ManagedResearchClient(ManagedResearchRunAuthorityMixin):
 
 
 class SmrControlClient(SmrControlClientMixin, ManagedResearchClient):
-    """Compatibility alias that retains the legacy synth-ai bridge surface.
+    """Compatibility alias with retired managed-agents bridge surfaces.
 
     `ManagedResearchClient` is the canonical public name. `SmrControlClient`
     remains as a one-release alias but requires callers to pass the selected
@@ -6166,10 +6166,6 @@ class SmrControlClient(SmrControlClientMixin, ManagedResearchClient):
         api_key: str | None = None,
         backend_base: str | None = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
-        openai_transport_mode: str = OPENAI_TRANSPORT_MODE_AUTO,
-        openai_organization: str | None = None,
-        openai_project: str | None = None,
-        openai_request_id: str | None = None,
     ) -> None:
         explicit_backend_base = str(backend_base or "").strip()
         if not explicit_backend_base:
@@ -6182,12 +6178,6 @@ class SmrControlClient(SmrControlClientMixin, ManagedResearchClient):
             api_key=api_key,
             backend_base=explicit_backend_base,
             timeout_seconds=timeout_seconds,
-        )
-        self._initialize_openai_bridge(
-            openai_transport_mode=openai_transport_mode,
-            openai_organization=openai_organization,
-            openai_project=openai_project,
-            openai_request_id=openai_request_id,
         )
 
     def close(self) -> None:

--- a/synth_ai/managed_research/sdk/compat.py
+++ b/synth_ai/managed_research/sdk/compat.py
@@ -1,100 +1,34 @@
-"""Compatibility surfaces for older SDK entrypoints.
-
-The optional ``synth-ai`` bridge is loaded only when callers use OpenAI Agents SDK
-helpers; ``ImportError`` is translated to a single actionable ``RuntimeError``.
-
-# See: Synth Style — compatibility layers isolated; never hide causes (``from exc``).
-"""
+"""Retired compatibility surfaces for older managed-agents entrypoints."""
 
 from __future__ import annotations
 
-from typing import Any
-
-from synth_ai.managed_research.sdk.config import (
-    OPENAI_TRANSPORT_MODE_AUTO,
-    optional_str,
-    resolve_openai_transport_mode,
-)
-
 
 class SmrControlClientMixin:
-    """Optional synth-ai bridge retained for one compatibility window."""
+    """Fail loudly for bridges whose backend policy boundary was retired."""
 
-    openai_transport_mode: str
-    openai_organization: str | None
-    openai_project: str | None
-    openai_request_id: str | None
-    _synth_client: Any | None
-
-    def _initialize_openai_bridge(
-        self,
-        *,
-        openai_transport_mode: str,
-        openai_organization: str | None,
-        openai_project: str | None,
-        openai_request_id: str | None,
-    ) -> None:
-        self.openai_transport_mode = resolve_openai_transport_mode(openai_transport_mode)
-        self.openai_organization = optional_str(openai_organization)
-        self.openai_project = optional_str(openai_project)
-        self.openai_request_id = optional_str(openai_request_id)
-        self._synth_client = None
-
-    def close_openai_bridge(self) -> None:
-        synth_client = getattr(self, "_synth_client", None)
-        if synth_client is not None:
-            close_fn = getattr(synth_client, "close", None)
-            if callable(close_fn):
-                close_fn()
-        self._synth_client = None
-
-    def _build_synth_client(
-        self,
-        *,
-        openai_transport_mode: str,
-        openai_organization: str | None,
-        openai_project: str | None,
-        openai_request_id: str | None,
-    ) -> Any:
-        try:
-            from synth_ai import SynthClient
-        except (
-            ImportError,
-            ModuleNotFoundError,
-        ) as exc:  # pragma: no cover - optional dependency path
-            raise RuntimeError(
-                "synth-ai is required for OpenAI Agents SDK access from managed-research. "
-                "Install it with `uv add synth-ai`."
-            ) from exc
-
-        return SynthClient(
-            api_key=self.api_key,
-            base_url=self.backend_base,
-            timeout=self.timeout_seconds,
-            openai_transport_mode=openai_transport_mode,
-            openai_organization=openai_organization,
-            openai_project=openai_project,
-            openai_request_id=openai_request_id,
+    @staticmethod
+    def _retired_bridge_error(surface: str) -> RuntimeError:
+        return RuntimeError(
+            f"{surface} was retired with the backend managed-agents proxy. "
+            "Use the explicit synth-ai Horizons Private client only when you have a "
+            "Horizons Private base URL and credential; a Synth API key is not a "
+            "replacement service credential."
         )
 
-    @property
-    def synth_ai(self) -> Any:
-        if self._synth_client is None:
-            self._synth_client = self._build_synth_client(
-                openai_transport_mode=self.openai_transport_mode,
-                openai_organization=self.openai_organization,
-                openai_project=self.openai_project,
-                openai_request_id=self.openai_request_id,
-            )
-        return self._synth_client
+    def close_openai_bridge(self) -> None:
+        """Retained as a no-op for callers that close the legacy bridge."""
 
     @property
-    def openai_agents_sdk(self) -> Any:
-        return self.synth_ai.openai_agents_sdk
+    def synth_ai(self) -> object:
+        raise self._retired_bridge_error("SmrControlClient.synth_ai")
 
     @property
-    def managed_agents(self) -> Any:
-        return self.synth_ai.managed_agents
+    def openai_agents_sdk(self) -> object:
+        raise self._retired_bridge_error("SmrControlClient.openai_agents_sdk")
+
+    @property
+    def managed_agents(self) -> object:
+        raise self._retired_bridge_error("SmrControlClient.managed_agents")
 
     def openai_agents_sdk_client(
         self,
@@ -103,26 +37,11 @@ class SmrControlClientMixin:
         openai_organization: str | None = None,
         openai_project: str | None = None,
         request_id: str | None = None,
-    ) -> Any:
-        if (
-            transport_mode is None
-            and openai_organization is None
-            and openai_project is None
-            and request_id is None
-        ):
-            return self.openai_agents_sdk
-
-        return self._build_synth_client(
-            openai_transport_mode=resolve_openai_transport_mode(
-                transport_mode or self.openai_transport_mode
-            ),
-            openai_organization=optional_str(openai_organization or self.openai_organization),
-            openai_project=optional_str(openai_project or self.openai_project),
-            openai_request_id=optional_str(request_id or self.openai_request_id),
-        ).openai_agents_sdk
+    ) -> object:
+        del transport_mode, openai_organization, openai_project, request_id
+        raise self._retired_bridge_error("SmrControlClient.openai_agents_sdk_client()")
 
 
 __all__ = [
-    "OPENAI_TRANSPORT_MODE_AUTO",
     "SmrControlClientMixin",
 ]

--- a/synth_ai/managed_research/sdk/config.py
+++ b/synth_ai/managed_research/sdk/config.py
@@ -13,9 +13,7 @@ OPENAI_TRANSPORT_MODE_BACKEND_BFF = "backend_bff"
 OPENAI_TRANSPORT_MODE_DIRECT_HP = "direct_hp"
 OPENAI_TRANSPORT_MODE_AUTO = "auto"
 OPENAI_VALID_TRANSPORT_MODES = {
-    OPENAI_TRANSPORT_MODE_BACKEND_BFF,
     OPENAI_TRANSPORT_MODE_DIRECT_HP,
-    OPENAI_TRANSPORT_MODE_AUTO,
 }
 
 
@@ -45,10 +43,21 @@ def optional_str(value: str | None) -> str | None:
 
 
 def resolve_openai_transport_mode(value: str | None) -> str:
-    normalized = str(value or OPENAI_TRANSPORT_MODE_AUTO).strip().lower()
+    normalized = str(value or "").strip().lower()
+    if normalized in {
+        OPENAI_TRANSPORT_MODE_AUTO,
+        OPENAI_TRANSPORT_MODE_BACKEND_BFF,
+    }:
+        raise ValueError(
+            f"openai_transport_mode={normalized!r} was retired with the backend "
+            "managed-agents proxy; direct_hp requires an explicit Horizons Private "
+            "base URL and credential"
+        )
     if normalized not in OPENAI_VALID_TRANSPORT_MODES:
-        allowed = ", ".join(sorted(OPENAI_VALID_TRANSPORT_MODES))
-        raise ValueError(f"openai_transport_mode must be one of: {allowed}")
+        raise ValueError(
+            "openai_transport_mode must be explicitly set to direct_hp with an explicit "
+            "Horizons Private base URL and credential"
+        )
     return normalized
 
 

--- a/synth_ai/sdk/managed_agents/client.py
+++ b/synth_ai/sdk/managed_agents/client.py
@@ -563,12 +563,10 @@ class SynthManagedAgents:
         transport: ManagedAgentsAnthropicClient | None = None,
     ) -> None:
         if transport is None:
-            transport = ManagedAgentsAnthropicClient(
-                api_key=api_key,
-                backend_base=base_url,
-                timeout=timeout,
-                anthropic_version=anthropic_version,
-                anthropic_beta=anthropic_beta,
+            raise ValueError(
+                "SynthManagedAgents has no implicit transport after retirement of the "
+                "backend managed-agents proxy. Use from_horizons_private() with an "
+                "explicit Horizons Private base URL and credential."
             )
         self._transport = transport
         self.webhook_key = webhook_key
@@ -579,7 +577,7 @@ class SynthManagedAgents:
         cls,
         *,
         base_url: str,
-        api_key: str | None = None,
+        api_key: str,
         timeout: float = 30.0,
         anthropic_version: str | None = None,
         webhook_key: str | bytes | None = None,
@@ -861,13 +859,10 @@ class AsyncSynthManagedAgents:
         sync_client: SynthManagedAgents | None = None,
     ) -> None:
         if sync_client is None:
-            sync_client = SynthManagedAgents(
-                api_key=api_key,
-                base_url=base_url,
-                timeout=timeout,
-                anthropic_version=anthropic_version,
-                anthropic_beta=anthropic_beta,
-                webhook_key=webhook_key,
+            raise ValueError(
+                "AsyncSynthManagedAgents has no implicit transport after retirement of "
+                "the backend managed-agents proxy. Use from_horizons_private() with an "
+                "explicit Horizons Private base URL and credential."
             )
         self._sync = sync_client
         self.beta = _AsyncBetaResource(sync_client.beta)
@@ -877,7 +872,7 @@ class AsyncSynthManagedAgents:
         cls,
         *,
         base_url: str,
-        api_key: str | None = None,
+        api_key: str,
         timeout: float = 30.0,
         anthropic_version: str | None = None,
         webhook_key: str | bytes | None = None,

--- a/synth_ai/sdk/managed_agents_anthropic.py
+++ b/synth_ai/sdk/managed_agents_anthropic.py
@@ -1,4 +1,4 @@
-"""Anthropic-view managed-agents client (via backend BFF proxy)."""
+"""Anthropic-view managed-agents client for explicit Horizons Private access."""
 
 from __future__ import annotations
 
@@ -12,8 +12,7 @@ from typing import Any
 
 import httpx
 
-from synth_ai.core.utils.env import get_api_key
-from synth_ai.core.utils.urls import BACKEND_URL_BASE, join_url, normalize_backend_base
+from synth_ai.core.utils.urls import join_url, normalize_backend_base
 
 DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
 DEFAULT_MANAGED_AGENTS_BETA = (
@@ -110,7 +109,7 @@ class ManagedAgentRun:
 
 
 class ManagedAgentsAnthropicClient:
-    """Sync client for backend Anthropic-view managed-agents proxy endpoints."""
+    """Sync client for an explicitly configured managed-agents transport."""
 
     def __init__(
         self,
@@ -119,14 +118,32 @@ class ManagedAgentsAnthropicClient:
         backend_base: str | None = None,
         timeout: float = 30.0,
         anthropic_version: str | None = None,
-        path_prefix: str = "/api/managed-agents/anthropic/v1",
+        path_prefix: str | None = None,
         require_api_key: bool = True,
         anthropic_beta: str | None = None,
     ) -> None:
-        self._api_key = (api_key or get_api_key(required=False) or "").strip()
+        prefix = str(path_prefix or "").strip().rstrip("/")
+        if not prefix:
+            raise ValueError(
+                "ManagedAgentsAnthropicClient has no implicit transport after retirement of "
+                "the backend managed-agents proxy. Use from_horizons_private() with an "
+                "explicit Horizons Private base URL and credential."
+            )
+        if prefix == "/api/managed-agents/anthropic/v1":
+            raise ValueError(
+                "The backend managed-agents Anthropic proxy has been retired. Use "
+                "from_horizons_private() only with an explicit Horizons Private base URL "
+                "and credential."
+            )
+        explicit_base = str(backend_base or "").strip()
+        if not explicit_base:
+            raise ValueError(
+                "backend_base is required for explicit managed-agents transport access"
+            )
+        self._api_key = str(api_key or "").strip()
         if require_api_key and not self._api_key:
-            raise ValueError("api_key is required (provide explicitly or set SYNTH_API_KEY)")
-        self._backend_base = normalize_backend_base(backend_base or BACKEND_URL_BASE)
+            raise ValueError("api_key must be an explicit credential for the selected transport")
+        self._backend_base = normalize_backend_base(explicit_base)
         self._timeout = timeout
         self._anthropic_version = (
             anthropic_version or os.getenv("ANTHROPIC_VERSION") or DEFAULT_ANTHROPIC_VERSION
@@ -134,26 +151,26 @@ class ManagedAgentsAnthropicClient:
         self._anthropic_beta = (
             anthropic_beta or os.getenv("ANTHROPIC_BETA") or DEFAULT_MANAGED_AGENTS_BETA
         ).strip()
-        self._prefix = path_prefix.rstrip("/")
+        self._prefix = prefix
 
     @classmethod
     def from_horizons_private(
         cls,
         *,
         base_url: str,
-        api_key: str | None = None,
+        api_key: str,
         timeout: float = 30.0,
         anthropic_version: str | None = None,
         anthropic_beta: str | None = None,
     ) -> ManagedAgentsAnthropicClient:
         return cls(
-            api_key=api_key or "",
+            api_key=api_key,
             backend_base=base_url,
             timeout=timeout,
             anthropic_version=anthropic_version or DEFAULT_ANTHROPIC_VERSION,
             anthropic_beta=anthropic_beta or DEFAULT_MANAGED_AGENTS_BETA,
             path_prefix="/anthropic/v1",
-            require_api_key=False,
+            require_api_key=True,
         )
 
     def _headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:

--- a/synth_ai/sdk/openai_agents_sdk.py
+++ b/synth_ai/sdk/openai_agents_sdk.py
@@ -1,4 +1,4 @@
-"""OpenAI Agents SDK compatibility client with dual transport support."""
+"""OpenAI Agents SDK compatibility client for explicit Horizons Private access."""
 
 from __future__ import annotations
 
@@ -9,20 +9,15 @@ from typing import Any
 
 import httpx
 
-from synth_ai.core.utils.env import get_api_key
-from synth_ai.core.utils.urls import BACKEND_URL_BASE, join_url, normalize_backend_base
+from synth_ai.core.utils.urls import join_url, normalize_backend_base
 
 TRANSPORT_MODE_BACKEND_BFF = "backend_bff"
 TRANSPORT_MODE_DIRECT_HP = "direct_hp"
 TRANSPORT_MODE_AUTO = "auto"
 VALID_TRANSPORT_MODES = {
-    TRANSPORT_MODE_BACKEND_BFF,
     TRANSPORT_MODE_DIRECT_HP,
-    TRANSPORT_MODE_AUTO,
 }
-FALLBACK_STATUS_CODES = {404, 405, 501}
 
-BACKEND_BFF_PREFIX = "/api/managed-agents/openai/v1"
 DIRECT_HP_PREFIX = "/openai/v1"
 
 
@@ -35,28 +30,66 @@ class OpenAIAgentsSdkClient:
         api_key: str | None = None,
         backend_base: str | None = None,
         timeout: float = 30.0,
-        transport_mode: str = TRANSPORT_MODE_AUTO,
+        transport_mode: str | None = None,
         openai_organization: str | None = None,
         openai_project: str | None = None,
         request_id: str | None = None,
     ) -> None:
-        self._api_key = (api_key or get_api_key(required=False) or "").strip()
-        if not self._api_key:
-            raise ValueError("api_key is required (provide explicitly or set SYNTH_API_KEY)")
-        self._backend_base = normalize_backend_base(backend_base or BACKEND_URL_BASE)
-        self._timeout = timeout
         self._transport_mode = self._validate_transport_mode(transport_mode)
+        explicit_base = str(backend_base or "").strip()
+        if not explicit_base:
+            raise ValueError(
+                "backend_base must be an explicit Horizons Private base URL for direct_hp"
+            )
+        self._api_key = str(api_key or "").strip()
+        if not self._api_key:
+            raise ValueError(
+                "api_key must be an explicit Horizons Private credential for direct_hp; "
+                "SYNTH_API_KEY is not reused across this authority boundary"
+            )
+        self._backend_base = normalize_backend_base(explicit_base)
+        self._timeout = timeout
         self._openai_organization = str(openai_organization or "").strip() or None
         self._openai_project = str(openai_project or "").strip() or None
         self._request_id = str(request_id or "").strip() or None
 
     @staticmethod
-    def _validate_transport_mode(value: str) -> str:
+    def _validate_transport_mode(value: str | None) -> str:
         normalized = str(value or "").strip().lower()
+        if normalized in {TRANSPORT_MODE_AUTO, TRANSPORT_MODE_BACKEND_BFF}:
+            raise ValueError(
+                f"transport_mode={normalized!r} was retired with the backend managed-agents "
+                "proxy; use direct_hp only with an explicit Horizons Private base URL and "
+                "credential"
+            )
         if normalized not in VALID_TRANSPORT_MODES:
-            allowed = ", ".join(sorted(VALID_TRANSPORT_MODES))
-            raise ValueError(f"transport_mode must be one of: {allowed}")
+            raise ValueError(
+                "transport_mode must be explicitly set to direct_hp with an explicit "
+                "Horizons Private base URL and credential"
+            )
         return normalized
+
+    @classmethod
+    def from_horizons_private(
+        cls,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: float = 30.0,
+        openai_organization: str | None = None,
+        openai_project: str | None = None,
+        request_id: str | None = None,
+    ) -> OpenAIAgentsSdkClient:
+        """Build a client for an explicit Horizons Private endpoint and credential."""
+        return cls(
+            api_key=api_key,
+            backend_base=base_url,
+            timeout=timeout,
+            transport_mode=TRANSPORT_MODE_DIRECT_HP,
+            openai_organization=openai_organization,
+            openai_project=openai_project,
+            request_id=request_id,
+        )
 
     @staticmethod
     def _normalize_path(path: str) -> str:
@@ -75,15 +108,9 @@ class OpenAIAgentsSdkClient:
         return {"content": response.text}
 
     @staticmethod
-    def _should_fallback(exc: Exception) -> bool:
-        if not isinstance(exc, httpx.HTTPStatusError):
-            return False
-        return exc.response.status_code in FALLBACK_STATUS_CODES
-
-    @staticmethod
     def _prefix_for_mode(mode: str) -> str:
-        if mode == TRANSPORT_MODE_BACKEND_BFF:
-            return BACKEND_BFF_PREFIX
+        if mode != TRANSPORT_MODE_DIRECT_HP:
+            raise ValueError(f"unsupported transport mode: {mode}")
         return DIRECT_HP_PREFIX
 
     def _headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
@@ -128,35 +155,14 @@ class OpenAIAgentsSdkClient:
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> Any:
-        if self._transport_mode != TRANSPORT_MODE_AUTO:
-            return self._request_once(
-                prefix=self._prefix_for_mode(self._transport_mode),
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            )
-        try:
-            return self._request_once(
-                prefix=BACKEND_BFF_PREFIX,
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            )
-        except Exception as exc:
-            if not self._should_fallback(exc):
-                raise
-            return self._request_once(
-                prefix=DIRECT_HP_PREFIX,
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            )
+        return self._request_once(
+            prefix=self._prefix_for_mode(self._transport_mode),
+            method=method,
+            path=path,
+            json_body=json_body,
+            params=params,
+            headers=headers,
+        )
 
     @staticmethod
     def _parse_sse_data(payload: str) -> Any:
@@ -264,39 +270,14 @@ class OpenAIAgentsSdkClient:
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> Iterator[dict[str, Any]]:
-        if self._transport_mode != TRANSPORT_MODE_AUTO:
-            return self._stream_once(
-                prefix=self._prefix_for_mode(self._transport_mode),
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            )
-
-        def _iter_auto() -> Iterator[dict[str, Any]]:
-            try:
-                yield from self._stream_once(
-                    prefix=BACKEND_BFF_PREFIX,
-                    method=method,
-                    path=path,
-                    json_body=json_body,
-                    params=params,
-                    headers=headers,
-                )
-            except Exception as exc:
-                if not self._should_fallback(exc):
-                    raise
-                yield from self._stream_once(
-                    prefix=DIRECT_HP_PREFIX,
-                    method=method,
-                    path=path,
-                    json_body=json_body,
-                    params=params,
-                    headers=headers,
-                )
-
-        return _iter_auto()
+        return self._stream_once(
+            prefix=self._prefix_for_mode(self._transport_mode),
+            method=method,
+            path=path,
+            json_body=json_body,
+            params=params,
+            headers=headers,
+        )
 
     # /responses family
     def create_response(self, request: dict[str, Any]) -> dict[str, Any]:
@@ -500,43 +481,15 @@ class AsyncOpenAIAgentsSdkClient:
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        if self._sync._transport_mode != TRANSPORT_MODE_AUTO:
-            async for frame in self._async_stream_once(
-                prefix=self._sync._prefix_for_mode(self._sync._transport_mode),
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            ):
-                yield frame
-            return
-
-        # auto mode: BFF first; fallback to direct HP only on FALLBACK_STATUS_CODES.
-        # raise_for_status() fires before any frames are yielded, so the fallback
-        # is safe — no frames have been emitted when the exception propagates.
-        try:
-            async for frame in self._async_stream_once(
-                prefix=BACKEND_BFF_PREFIX,
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            ):
-                yield frame
-        except Exception as exc:
-            if not self._sync._should_fallback(exc):
-                raise
-            async for frame in self._async_stream_once(
-                prefix=DIRECT_HP_PREFIX,
-                method=method,
-                path=path,
-                json_body=json_body,
-                params=params,
-                headers=headers,
-            ):
-                yield frame
+        async for frame in self._async_stream_once(
+            prefix=self._sync._prefix_for_mode(self._sync._transport_mode),
+            method=method,
+            path=path,
+            json_body=json_body,
+            params=params,
+            headers=headers,
+        ):
+            yield frame
 
     # ------------------------------------------------------------------
     # Public async API
@@ -651,9 +604,7 @@ class AsyncOpenAIAgentsSdkClient:
 
 __all__ = [
     "AsyncOpenAIAgentsSdkClient",
-    "BACKEND_BFF_PREFIX",
     "DIRECT_HP_PREFIX",
-    "FALLBACK_STATUS_CODES",
     "OpenAIAgentsSdkClient",
     "TRANSPORT_MODE_AUTO",
     "TRANSPORT_MODE_BACKEND_BFF",


### PR DESCRIPTION
## Summary
- remove implicit managed-agents BFF and auto-fallback transports after backend route retirement
- require explicit Horizons Private base URLs and credentials for the remaining direct clients
- make legacy bridge properties fail loudly instead of crossing the retired authority boundary

Backend authority: backend commit `5748ff6af`. This is intentionally separate from the scoped evidence-obligations SDK PR.

## Validation
- `git diff --cached --check`
- Python AST parse of all 7 changed Python files
- source scan confirmed no callable backend BFF/fallback symbols remain
- independent HIGH review found no correctness issues

Tests were not run per workspace instruction. Ruff and ty were not run because they were not explicitly requested.