### PR TITLE
chore(release): publish reviewer authority as 0.16.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.15.3.dev0"
+version = "0.16.1.dev0"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"


### PR DESCRIPTION
Bumps the dev prerelease to 0.16.1.dev0 so the merged reviewer_profile_id authority surface can publish through the existing trusted-publisher workflow. PyPI already contains stable 0.16.0 and the previous dev version 0.15.3.dev0, so this is the next prerelease line. No local tests, Ruff, or ty were run; hosted CI remains authoritative.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/synth-laboratories/synth-ai/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->