### PR TITLE
release: synth-ai 0.16.1 (reviewer profile authority)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `synth-ai` package are documented here.
 
 ## Unreleased
 
+## 0.16.1 — 2026-07-22
+
+### Added
+
+- **Explicit reviewer profile binding** — runnable-project / Research project
+  creation accepts optional `reviewer_profile_id` (and MCP/SDK equivalents) so
+  hosted BRSR lanes bind the platform-owned verifier without inferring it from
+  worker profile ordering. Missing SDK support fails closed.
+
+### Notes
+
+- Install: `pip install synth-ai==0.16.1`.
+- Backend production already serves the matching reviewer/inspection surfaces.
+
+
 ## 0.16.0 — 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.16.0-orange synth-ai==0.16.0 -->
+<!-- CI release pins: PyPI-0.16.1-orange synth-ai==0.16.1 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.16.0"
+version = "0.16.1"
 description = "Python-only SDK for Synth containers, tunnels, pools, and Research"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/managed_research/mcp/request_models.py
+++ b/synth_ai/managed_research/mcp/request_models.py
@@ -330,6 +330,9 @@ class RunnableProjectCreateRequest:
             "orchestrator_profile_id": require_string(payload, "orchestrator_profile_id"),
             "default_worker_profile_id": require_string(payload, "default_worker_profile_id"),
         }
+        reviewer_profile_id = payload.get("reviewer_profile_id")
+        if reviewer_profile_id is not None:
+            agent_profiles["reviewer_profile_id"] = require_string(payload, "reviewer_profile_id")
         worker_profile_ids = payload.get("worker_profile_ids")
         if worker_profile_ids is not None:
             if not isinstance(worker_profile_ids, list):

--- a/synth_ai/managed_research/mcp/tools/projects.py
+++ b/synth_ai/managed_research/mcp/tools/projects.py
@@ -123,6 +123,10 @@ def build_project_tools(server: Any) -> list[ToolDefinition]:
                         "type": "string",
                         "description": "Required shared orchestrator profile id.",
                     },
+                    "reviewer_profile_id": {
+                        "type": "string",
+                        "description": "Optional explicit reviewer profile id sealed by project authority.",
+                    },
                     "default_worker_profile_id": {
                         "type": "string",
                         "description": "Required default worker profile id.",

--- a/synth_ai/managed_research/models/types.py
+++ b/synth_ai/managed_research/models/types.py
@@ -1711,11 +1711,57 @@ class SmrResolvedActorProfiles:
     orchestrator: SmrResolvedProfile
     workers: tuple[SmrResolvedProfile, ...] = field(default_factory=tuple)
     default_worker_profile_id: str | None = None
+    reviewer: SmrResolvedProfile | None = None
 
     @classmethod
     def from_wire(cls, payload: object) -> SmrResolvedActorProfiles | None:
         if not isinstance(payload, Mapping):
             return None
+        direct_orchestrator = payload.get("orchestrator")
+        if isinstance(direct_orchestrator, Mapping):
+            orchestrator_id = str(direct_orchestrator.get("profile_id") or "").strip()
+            if not orchestrator_id:
+                return None
+            orchestrator = SmrResolvedProfile.from_wire(
+                role=SmrActorType.ORCHESTRATOR,
+                profile_id=orchestrator_id,
+                snapshot=direct_orchestrator,
+            )
+            if orchestrator is None:
+                return None
+            workers: list[SmrResolvedProfile] = []
+            direct_workers = payload.get("workers")
+            if isinstance(direct_workers, (list, tuple)):
+                for worker_payload in direct_workers:
+                    if not isinstance(worker_payload, Mapping):
+                        continue
+                    worker_id = str(worker_payload.get("profile_id") or "").strip()
+                    if not worker_id:
+                        continue
+                    worker = SmrResolvedProfile.from_wire(
+                        role=SmrActorType.WORKER,
+                        profile_id=worker_id,
+                        snapshot=worker_payload,
+                    )
+                    if worker is not None:
+                        workers.append(worker)
+            direct_reviewer = payload.get("reviewer")
+            reviewer: SmrResolvedProfile | None = None
+            if isinstance(direct_reviewer, Mapping):
+                reviewer_id = str(direct_reviewer.get("profile_id") or "").strip()
+                if reviewer_id:
+                    reviewer = SmrResolvedProfile.from_wire(
+                        role=SmrActorType.REVIEWER,
+                        profile_id=reviewer_id,
+                        snapshot=direct_reviewer,
+                    )
+            default_worker = payload.get("default_worker_profile_id")
+            return cls(
+                orchestrator=orchestrator,
+                workers=tuple(workers),
+                default_worker_profile_id=(str(default_worker) if default_worker else None),
+                reviewer=reviewer,
+            )
         resolved = payload.get("resolved_profiles")
         orchestrator_id = payload.get("orchestrator_profile_id")
         if not isinstance(resolved, Mapping) or not orchestrator_id:
@@ -1739,10 +1785,21 @@ class SmrResolvedActorProfiles:
                 if worker is not None:
                     workers.append(worker)
         default_worker = payload.get("default_worker_profile_id")
+        reviewer_id = payload.get("reviewer_profile_id")
+        reviewer = (
+            SmrResolvedProfile.from_wire(
+                role=SmrActorType.REVIEWER,
+                profile_id=str(reviewer_id),
+                snapshot=resolved.get(str(reviewer_id)),
+            )
+            if reviewer_id
+            else None
+        )
         return cls(
             orchestrator=orchestrator,
             workers=tuple(workers),
             default_worker_profile_id=(str(default_worker) if default_worker else None),
+            reviewer=reviewer,
         )
 
 
@@ -1826,16 +1883,20 @@ class SmrAgentProfileBindings:
     orchestrator_profile_id: str
     default_worker_profile_id: str
     worker_profile_ids: list[str] = field(default_factory=list)
+    reviewer_profile_id: str | None = None
 
     def to_wire(self) -> dict[str, object]:
         worker_profile_ids = list(self.worker_profile_ids)
         if not worker_profile_ids:
             worker_profile_ids = [self.default_worker_profile_id]
-        return {
+        payload: dict[str, object] = {
             "orchestrator_profile_id": self.orchestrator_profile_id,
             "default_worker_profile_id": self.default_worker_profile_id,
             "worker_profile_ids": worker_profile_ids,
         }
+        if self.reviewer_profile_id is not None:
+            payload["reviewer_profile_id"] = self.reviewer_profile_id
+        return payload
 
 
 @dataclass(frozen=True)
@@ -1916,6 +1977,10 @@ class SmrRunnableProjectRequest:
                     "default_worker_profile_id",
                     label="runnable project request.agent_profiles.default_worker_profile_id",
                 ),
+                reviewer_profile_id=_optional_string(
+                    agent_profiles_payload,
+                    "reviewer_profile_id",
+                ),
                 worker_profile_ids=worker_profile_ids,
             ),
             worker_profile_ids=worker_profile_ids,
@@ -1964,6 +2029,8 @@ class SmrRunnableProjectRequest:
             "policy": dict(self.policy),
             "trial_matrix": dict(self.trial_matrix),
         }
+        if self.agent_profiles.reviewer_profile_id is not None:
+            payload["reviewer_profile_id"] = self.agent_profiles.reviewer_profile_id
         if self.actor_model_assignments:
             payload["actor_model_assignments"] = [
                 item.as_payload() for item in self.actor_model_assignments

--- a/synth_ai/managed_research/schemas/smr_openapi.yaml
+++ b/synth_ai/managed_research/schemas/smr_openapi.yaml
@@ -54684,6 +54684,10 @@ components:
       properties:
         orchestrator:
           $ref: '#/components/schemas/SmrResolvedProfileResponse'
+        reviewer:
+          anyOf:
+          - $ref: '#/components/schemas/SmrResolvedProfileResponse'
+          - type: 'null'
         workers:
           items:
             $ref: '#/components/schemas/SmrResolvedProfileResponse'
@@ -54699,9 +54703,9 @@ components:
       - orchestrator
       title: SmrResolvedActorProfilesResponse
       description: "Platform-resolved actor execution for a hosted launch \u2014 no\
-        \ customer input.\n\nSurfaces what the platform chose (orchestrator + worker\
-        \ profiles) so history\nand dashboards never conflate requested vs platform-chosen\
-        \ models."
+        \ customer input.\n\nSurfaces what the platform chose (orchestrator, reviewer,\
+        \ and worker\nprofiles) so history and dashboards never conflate requested\
+        \ vs\nplatform-chosen models."
     SmrResolvedProfileResponse:
       properties:
         role:
@@ -60521,6 +60525,13 @@ components:
           maxLength: 200
           minLength: 1
           title: Orchestrator Profile Id
+        reviewer_profile_id:
+          anyOf:
+          - type: string
+            maxLength: 200
+            minLength: 1
+          - type: 'null'
+          title: Reviewer Profile Id
         default_worker_profile_id:
           type: string
           maxLength: 200


### PR DESCRIPTION
## Summary
- Cherry-pick `feat(research): expose reviewer profile binding` onto `main`.
- Bump package `0.16.0` → `0.16.1` and document in CHANGELOG/README pin.

## Publish
Merge to `main` triggers `publish-dev.yml` trusted publisher for exact version `0.16.1` (not yet on PyPI).

## Test plan
- [x] Cherry-pick applied cleanly
- [x] `reviewer_profile_id` present in models/types.py
- [ ] After merge: Actions publish green; `pip index` shows 0.16.1

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/synth-laboratories/synth-ai/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->