### PR TITLE
fix(research): retry typed project archive safely

### DIFF
--- a/synth_ai/core/research/contracts/_wire.py
+++ b/synth_ai/core/research/contracts/_wire.py
@@ -60,10 +60,17 @@ def required_datetime(payload: JsonObject, name: str) -> datetime:
     return parsed
 
 
+def optional_datetime(payload: JsonObject, name: str) -> datetime | None:
+    if payload.get(name) is None:
+        return None
+    return required_datetime(payload, name)
+
+
 __all__ = [
     "array_value",
     "object_value",
     "optional_bool",
+    "optional_datetime",
     "optional_text",
     "required_bool",
     "required_datetime",

--- a/synth_ai/core/research/contracts/projects.py
+++ b/synth_ai/core/research/contracts/projects.py
@@ -10,6 +10,7 @@ from synth_ai.core.contracts.json_value import JsonObject, JsonValue
 from synth_ai.core.research.contracts._wire import (
     object_value,
     optional_bool,
+    optional_datetime,
     optional_text,
     required_datetime,
     required_text,
@@ -124,6 +125,7 @@ class Project:
     created_at: datetime
     updated_at: datetime
     archived: bool = False
+    archived_at: datetime | None = None
     project_alias: str | None = None
     project_kind: str | None = None
     active_swarm_id: SwarmId | None = None
@@ -142,6 +144,7 @@ class Project:
             created_at=required_datetime(payload, "created_at"),
             updated_at=required_datetime(payload, "updated_at"),
             archived=optional_bool(payload, "archived"),
+            archived_at=optional_datetime(payload, "archived_at"),
             project_alias=optional_text(payload, "project_alias"),
             project_kind=optional_text(payload, "project_kind"),
             active_swarm_id=SwarmId(active_swarm) if active_swarm is not None else None,

--- a/synth_ai/core/research/operations.py
+++ b/synth_ai/core/research/operations.py
@@ -26,7 +26,11 @@ RESEARCH_OPERATIONS = {
             "archive_factory", HttpMethod.POST, "/smr/factories/{factory_id}/archive", mutation=True
         ),
         _operation(
-            "archive_project", HttpMethod.POST, "/smr/projects/{project_id}/archive", mutation=True
+            "archive_project",
+            HttpMethod.POST,
+            "/smr/projects/{project_id}/archive",
+            mutation=True,
+            idempotent=True,
         ),
         _operation(
             "confirm_project_workspace_push",

--- a/synth_ai/core/research/projects.py
+++ b/synth_ai/core/research/projects.py
@@ -35,12 +35,14 @@ def _request(
     *,
     query: JsonObject | None = None,
     body: JsonObject | None = None,
+    headers: dict[str, str] | None = None,
 ) -> HttpRequest:
     return HttpRequest(
         research_operation(operation_id),
         path,
         query=query or {},
         body=body,
+        headers=headers or {},
     )
 
 
@@ -121,7 +123,11 @@ class ProjectsAPI:
 
     def archive(self, project_id: ProjectId) -> Project:
         value = self._transport.execute(
-            _request("archive_project", f"/smr/projects/{project_id}/archive")
+            _request(
+                "archive_project",
+                f"/smr/projects/{project_id}/archive",
+                headers={"Idempotency-Key": f"archive-project:{project_id}"},
+            )
         )
         return Project.from_wire(value)
 
@@ -196,7 +202,11 @@ class AsyncProjectsAPI:
 
     async def archive(self, project_id: ProjectId) -> Project:
         value = await self._transport.execute(
-            _request("archive_project", f"/smr/projects/{project_id}/archive")
+            _request(
+                "archive_project",
+                f"/smr/projects/{project_id}/archive",
+                headers={"Idempotency-Key": f"archive-project:{project_id}"},
+            )
         )
         return Project.from_wire(value)
 


### PR DESCRIPTION
Adds deterministic archive idempotency keys, declares archive as an idempotent operation for typed transient retries, and decodes archived_at on Project. This is the synth-ai half of the Luna README smoke archive convergence path.\n\nValidation: python3 -m py_compile on the four changed modules; git diff --check; live staging archive and SynthReBench README smoke both succeeded. No Ruff/ty or test suite per workspace guardrails.