### PR TITLE
Improve SDK reference documentation

### DIFF
--- a/scripts/sdk_docs_postprocess.py
+++ b/scripts/sdk_docs_postprocess.py
@@ -38,6 +38,161 @@ STATUS_CONFIG: dict[str, tuple[str, str, str]] = {
     "beta": ("BETA", "blue", "circle-check"),
 }
 
+SIGNATURE_REPLACEMENTS: dict[str, dict[str, str]] = {
+    "containers-client.mdx": {
+        "create(self, spec: ContainerSpec) -> Container": (
+            "create(self, spec: ContainerSpec, *, "
+            "timeout_seconds: float | None = None) -> Container"
+        ),
+        "get(self, container_id: str) -> Container": (
+            "get(self, container_id: str, *, "
+            "timeout_seconds: float | None = None) -> Container"
+        ),
+        "list(self) -> builtins.list[Container]": (
+            "list(self, *, timeout_seconds: float | None = None) "
+            "-> builtins.list[Container]"
+        ),
+        "delete(self, container_id: str) -> None": (
+            "delete(self, container_id: str, *, "
+            "timeout_seconds: float | None = None) -> None"
+        ),
+        "wait_ready(self, container_id: str) -> Container": (
+            "wait_ready(self, container_id: str, *, "
+            "timeout_seconds: float = 300.0, "
+            "poll_interval_seconds: float = 2.0, "
+            "timeout: float | None = None, "
+            "poll_interval: float | None = None) -> Container"
+        ),
+    },
+    "pools-client.mdx": {
+        "list_pools(self) -> dict[str, Any]": (
+            "list_pools(self, *, state: str | None = None, limit: int = 100, "
+            "cursor: str | None = None) -> dict[str, Any]"
+        ),
+        "list(self) -> dict[str, Any]": (
+            "list(self, *, state: str | None = None, limit: int = 100, "
+            "cursor: str | None = None) -> dict[str, Any]"
+        ),
+        "list_rollouts(self, pool_id: str) -> dict[str, Any]": (
+            "list_rollouts(self, pool_id: str, *, state: str | None = None, "
+            "limit: int = 100, cursor: str | None = None) -> dict[str, Any]"
+        ),
+        (
+            "stream_rollout_events(self, pool_id: str, rollout_id: str) "
+            "-> Iterator[dict[str, Any]]"
+        ): (
+            "stream_rollout_events(self, pool_id: str, rollout_id: str, *, "
+            "cursor: str | None = None) -> Iterator[dict[str, Any]]"
+        ),
+        "list_global_rollouts(self) -> dict[str, Any]": (
+            "list_global_rollouts(self, *, state: str | None = None, "
+            "limit: int = 100, cursor: str | None = None) -> dict[str, Any]"
+        ),
+        (
+            "stream_global_rollout_events(self, rollout_id: str) "
+            "-> Iterator[dict[str, Any]]"
+        ): (
+            "stream_global_rollout_events(self, rollout_id: str, *, "
+            "cursor: str | None = None) -> Iterator[dict[str, Any]]"
+        ),
+    },
+}
+
+ASYNC_RESEARCH_REFERENCE = """---
+title: AsyncResearchClient
+sidebarTitle: AsyncResearchClient
+---
+
+# `synth_ai.research.async_client`
+
+`AsyncResearchClient` is the native asynchronous Research client. It has the
+same resource namespaces as the typed core synchronous client, but network
+operations are awaitable and the transport is closed with `await close()` or
+`async with`.
+
+This is a direct alias of the typed core `AsyncClient`; it does **not** return a
+thread-offloaded or opaque namespace proxy. Unlike the public synchronous
+`ResearchClient` wrapper, it does not expose the `advanced` namespace or the
+deprecated `runs` alias; use the typed namespaces below.
+
+## Construct the client
+
+| Argument | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `api_key` | `str | None` | `None` | Uses `SYNTH_API_KEY` when omitted. |
+| `base_url` | `str | None` | `None` | Uses the environment-selected backend when omitted; an unconfigured development shell defaults to `http://localhost:8000`. |
+| `timeout_seconds` | `float` | `30.0` | Default HTTP timeout for resource operations. |
+
+```python
+import asyncio
+
+from synth_ai.research.async_client import AsyncResearchClient
+
+
+async def main() -> None:
+    async with AsyncResearchClient() as research:
+        projects = await research.projects.list(limit=20)
+        for project in projects:
+            print(project.project_id, project.name)
+
+
+asyncio.run(main())
+```
+
+Expected output is one line per visible project containing its stable ID and
+name. An organization with no projects produces no lines.
+
+## Namespaces
+
+| Namespace | Type | Use |
+| --- | --- | --- |
+| `projects` | `AsyncProjectsAPI` | Create, list, read, update, and archive projects. |
+| `swarms` | `AsyncSwarmsAPI` | Launch and inspect hosted swarms. |
+| `factories` | `AsyncFactoriesAPI` | Operate recurring Research Factory programs. |
+| `environments` | `AsyncEnvironmentsAPI` | Inspect execution environments. |
+| `image_releases` | `AsyncImageReleasesAPI` | Inspect released runtime images. |
+| `economics` | `AsyncEconomicsAPI` | Read metered economics; loaded on first access. |
+| `limits` | `AsyncLimitsAPI` | Read organization limits; loaded on first access. |
+| `credential` | `ApiCredential` | Read the validated credential object without exposing it in `repr`. |
+
+Each namespace documents its own method parameters, return models, and
+operation-specific failures. The async client returns the same typed models as
+the synchronous client.
+
+## Lifecycle
+
+Prefer `async with`; it closes the shared HTTP transport even when an operation
+raises:
+
+```python
+async with AsyncResearchClient() as research:
+    project = await research.projects.retrieve(project_id)
+    print(project.project_id)
+```
+
+For a longer-lived client, call `await research.close()` exactly once when its
+owner shuts down.
+
+## Errors and next actions
+
+| Error | Cause | Action |
+| --- | --- | --- |
+| `AuthenticationError` | No API key or an empty key during client construction. | Set `SYNTH_API_KEY` or pass a non-empty `api_key`. |
+| `AuthorizationError` | The credential lacks authority for the resource. | Use the owning organization or request access; do not retry unchanged. |
+| `ResearchOperationError` | A request is rejected without a narrower typed failure; `failure.category` distinguishes authentication, validation, and other causes. | Follow the category and status; correct invalid input or credentials before retrying. |
+| `ConflictError` | The mutation conflicts with current resource state. | Read the resource, reconcile its state, then issue a new mutation. |
+| `PaymentRequiredError` | A `402` response reports exhausted credits or another payment requirement. | Inspect economics and billing state before retrying. |
+| `RateLimitedError` | A rate limit denied the operation. | Respect `retry_after_seconds` when present. |
+| `TransientServiceError` | A classified temporary service failure. | Retry only according to the exception's retry metadata. |
+
+All operation exceptions carry a structured `failure` record when the service
+provides one. Preserve `request_id`, `error_code`, and retry metadata when
+reporting an incident.
+
+See also: [ResearchClient](/reference/sdk/research/synth_ai-research-client) and
+[Errors](/reference/sdk/research/synth_ai-research-errors).
+"""
+
 
 def wrap_examples_in_code_blocks(content: str) -> str:
     """Wrap indented Example sections in fenced ```python blocks."""
@@ -55,6 +210,8 @@ def wrap_examples_in_code_blocks(content: str) -> str:
             while index < len(lines) and lines[index].strip() == "":
                 result.append(lines[index])
                 index += 1
+            if not result or result[-1].strip():
+                result.append("")
 
             code_lines: list[str] = []
             while index < len(lines) and (
@@ -85,6 +242,35 @@ def wrap_examples_in_code_blocks(content: str) -> str:
 
         result.append(line)
         index += 1
+
+    return "\n".join(result)
+
+
+def normalize_labeled_prose(content: str) -> str:
+    """Render module-level prose labels as readable Markdown, not code blocks."""
+    labels = {"Availability", "Contract", "Errors", "Expected output", "Pagination"}
+    lines = content.split("\n")
+    result: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        label = lines[index].strip().removesuffix(":")
+        if label not in labels:
+            result.append(lines[index])
+            index += 1
+            continue
+
+        result.extend([f"**{label}:**", ""])
+        index += 1
+        while index < len(lines) and (
+            lines[index].startswith("    ") or not lines[index].strip()
+        ):
+            result.append(
+                lines[index][4:]
+                if lines[index].startswith("    ")
+                else lines[index]
+            )
+            index += 1
 
     return "\n".join(result)
 
@@ -160,6 +346,74 @@ def fix_see_also_sections(content: str) -> str:
     return "\n".join(result)
 
 
+def normalize_rst_inline_markup(content: str) -> str:
+    """Convert common reStructuredText inline roles to Markdown code spans."""
+    lines = content.split("\n")
+    result: list[str] = []
+    in_code_block = False
+
+    for line in lines:
+        if line.strip().startswith("```"):
+            in_code_block = not in_code_block
+            result.append(line)
+            continue
+        if in_code_block:
+            result.append(line)
+            continue
+
+        line = re.sub(
+            r":(?:attr|class|data|func|meth):`~?([^`]+)`",
+            r"`\1`",
+            line,
+        )
+        line = re.sub(r"``([^`\n]+)``", r"`\1`", line)
+        result.append(line)
+
+    return "\n".join(result)
+
+
+def indent_wrapped_list_continuations(content: str) -> str:
+    """Keep mdxify-wrapped list descriptions attached to their bullets."""
+    lines = content.split("\n")
+    result: list[str] = []
+    in_code_block = False
+    in_list_item = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            in_list_item = False
+            result.append(line)
+            continue
+        if in_code_block:
+            result.append(line)
+            continue
+
+        if line.startswith("- "):
+            in_list_item = True
+            result.append(line)
+            continue
+        if not stripped or stripped.startswith("#") or stripped.startswith("**"):
+            in_list_item = False
+            result.append(line)
+            continue
+        if in_list_item and not line.startswith(("  ", "\t")):
+            result.append(f"  {line}")
+            continue
+
+        result.append(line)
+
+    return "\n".join(result)
+
+
+def restore_keyword_only_signatures(content: str, filename: str) -> str:
+    """Repair signatures whose keyword-only parameters mdxify omits."""
+    for generated, actual in SIGNATURE_REPLACEMENTS.get(filename, {}).items():
+        content = content.replace(generated, actual)
+    return content
+
+
 def apply_title_mappings(content: str, filename: str) -> str:
     """Replace mdxify module titles with customer-facing sidebar names."""
     if filename not in TITLE_MAPPINGS:
@@ -221,8 +475,14 @@ def extract_and_add_status_tags(content: str) -> str:
 
 def postprocess_mdx_file(content: str, filename: str) -> str:
     """Run the full postprocess pipeline on one MDX file."""
+    if filename == "synth_ai-research-async_client.mdx":
+        content = ASYNC_RESEARCH_REFERENCE
     content = wrap_examples_in_code_blocks(content)
+    content = normalize_labeled_prose(content)
     content = fix_see_also_sections(content)
+    content = normalize_rst_inline_markup(content)
+    content = indent_wrapped_list_continuations(content)
+    content = restore_keyword_only_signatures(content, filename)
     content = escape_remaining_curly_braces(content)
     content = apply_title_mappings(content, filename)
     content = extract_and_add_status_tags(content)

--- a/synth_ai/sdk/containers.py
+++ b/synth_ai/sdk/containers.py
@@ -1,6 +1,29 @@
-"""Hosted Containers SDK — create, manage, and reference hosted containers by ID.
+"""Hosted Containers SDK — create, inspect, wait for, and delete containers.
 
-Access via ``SynthClient().containers``.
+Access this API through ``SynthClient().containers``. The client reads
+``SYNTH_API_KEY`` when ``api_key`` is omitted and uses the environment-selected
+backend when ``backend_base`` is omitted. An unconfigured development shell
+defaults to ``http://localhost:8000``.
+
+Availability:
+    This is a compatibility client for deployments that expose
+    ``/v1/containers``. The SDK's bundled OpenAPI file describes those routes,
+    but the current production backend and its live OpenAPI contract route
+    hosted workloads through ``/v1/pools``. Use ``SynthClient().pools`` for the
+    portable production workflow, and use this client only when your target
+    deployment exposes the compatibility routes.
+
+Contract:
+    Container names are organization-scoped. ``definition`` and
+    ``environment_config`` are backend-owned JSON contracts for the selected
+    ``task_type``; use the corresponding container guide rather than guessing
+    fields.
+
+Errors:
+    HTTP failures raise ``httpx.HTTPStatusError``. A missing API key fails
+    before the first request with a ``ValueError`` that names
+    ``SYNTH_API_KEY``. Invalid response data raises
+    ``pydantic.ValidationError`` instead of returning a partial model.
 """
 
 from __future__ import annotations
@@ -34,7 +57,16 @@ class ContainerType(str, Enum):
 
 
 class ContainerSpec(BaseModel):
-    """Specification for creating a hosted container."""
+    """Validated request for creating one hosted container.
+
+    Attributes:
+        name: Organization-scoped container name. This field is required.
+        task_type: Required provisioning substrate selected from ``ContainerType``.
+        definition: Backend-owned definition for ``task_type``; defaults to an empty object.
+        environment_config: Optional overrides; defaults to ``None`` and is omitted when unset.
+        internal_url: Optional existing runtime URL. Defaults to ``None``; the
+            service supplies a placeholder when omitted.
+    """
 
     name: str = Field(..., description="Unique name for this container within the org")
     task_type: ContainerType = Field(..., description="Type of container to provision")
@@ -53,7 +85,18 @@ class ContainerSpec(BaseModel):
 
 
 class Container(BaseModel):
-    """Response model for a hosted container."""
+    """Validated hosted-container response.
+
+    Attributes:
+        id: Stable container identifier used by ``get``, ``delete``, and
+            ``wait_ready``.
+        name: Organization-scoped container name.
+        task_type: Provisioning substrate reported by the service.
+        status: Current lifecycle state.
+        internal_url: Runtime URL when one is available.
+        created_at: Service creation timestamp when supplied.
+        updated_at: Service update timestamp when supplied.
+    """
 
     id: str
     name: str
@@ -65,7 +108,25 @@ class Container(BaseModel):
 
 
 class ContainersClient(SynthBaseClient):
-    """Create and manage hosted environment containers."""
+    """Create and manage hosted environment containers.
+
+    Args:
+        api_key: Synth API key. Defaults to ``SYNTH_API_KEY``.
+        backend_base: API base URL. Defaults to the environment-selected
+            backend; an unconfigured development shell uses localhost.
+        timeout_seconds: Default HTTP timeout in seconds. Defaults to ``30``.
+
+    Raises:
+        ValueError: The API key is missing.
+        httpx.HTTPStatusError: The service rejects an operation.
+        pydantic.ValidationError: A service response does not match ``Container``.
+
+    Availability:
+        Methods require a deployment that exposes ``/v1/containers``. Although
+        the SDK's bundled OpenAPI file describes those routes, the current
+        production backend directs hosted workloads through
+        ``SynthClient().pools``.
+    """
 
     def __init__(
         self,
@@ -87,7 +148,21 @@ class ContainersClient(SynthBaseClient):
         *,
         timeout_seconds: float | None = None,
     ) -> Container:
-        """Provision a new hosted container from a :class:`ContainerSpec`."""
+        """Provision one hosted container.
+
+        Args:
+            spec: Validated container definition.
+            timeout_seconds: Per-request timeout override. Defaults to the
+                client timeout.
+
+        Returns:
+            The created ``Container``; provisioning may still be in progress.
+
+        Raises:
+            httpx.HTTPStatusError: Authentication, authorization, validation,
+                conflict, quota, or service errors.
+            pydantic.ValidationError: The response is not a valid ``Container``.
+        """
         payload = spec.model_dump(exclude_none=True)
         return self.cast_to(
             Container,
@@ -105,7 +180,21 @@ class ContainersClient(SynthBaseClient):
         *,
         timeout_seconds: float | None = None,
     ) -> Container:
-        """Retrieve a container by id."""
+        """Retrieve one container by ID.
+
+        Args:
+            container_id: Stable ID returned by ``create`` or ``list``.
+            timeout_seconds: Per-request timeout override. Defaults to the
+                client timeout.
+
+        Returns:
+            The current ``Container`` record.
+
+        Raises:
+            httpx.HTTPStatusError: The container is unavailable or the request
+                is rejected.
+            pydantic.ValidationError: The response is not a valid ``Container``.
+        """
         return self.cast_to(
             Container,
             self._request(
@@ -120,7 +209,19 @@ class ContainersClient(SynthBaseClient):
         *,
         timeout_seconds: float | None = None,
     ) -> builtins.list[Container]:
-        """List containers in the current organization."""
+        """List containers in the current organization.
+
+        Args:
+            timeout_seconds: Per-request timeout override. Defaults to the
+                client timeout.
+
+        Returns:
+            Validated ``Container`` records; an empty organization returns ``[]``.
+
+        Raises:
+            httpx.HTTPStatusError: The request is rejected.
+            pydantic.ValidationError: Any returned item is not a valid ``Container``.
+        """
         data = self._request("GET", self._prefix, timeout_seconds=timeout_seconds)
         items = data if isinstance(data, list) else data.get("items", [])
         return [self.cast_to(Container, item) for item in items]
@@ -131,7 +232,20 @@ class ContainersClient(SynthBaseClient):
         *,
         timeout_seconds: float | None = None,
     ) -> None:
-        """Delete a hosted container by id."""
+        """Delete one hosted container by ID.
+
+        Args:
+            container_id: Stable ID returned by ``create`` or ``list``.
+            timeout_seconds: Per-request timeout override. Defaults to the
+                client timeout.
+
+        Returns:
+            ``None`` after the service accepts the deletion.
+
+        Raises:
+            httpx.HTTPStatusError: The container is unavailable or the request
+                is rejected.
+        """
         self._request(
             "DELETE",
             f"{self._prefix}/{container_id}",
@@ -147,7 +261,24 @@ class ContainersClient(SynthBaseClient):
         timeout: float | None = None,
         poll_interval: float | None = None,
     ) -> Container:
-        """Poll until the container reaches 'ready' status or a terminal state."""
+        """Wait for ``ready``, ``failed``, or ``stopped``.
+
+        Args:
+            container_id: Stable ID returned by ``create`` or ``list``.
+            timeout_seconds: Best-effort polling window. Defaults to ``300``;
+                an in-flight read or sleep can finish after the nominal window.
+            poll_interval_seconds: Delay between reads. Defaults to ``2``.
+            timeout: Deprecated alias for ``timeout_seconds``.
+            poll_interval: Deprecated alias for ``poll_interval_seconds``.
+
+        Returns:
+            The first terminal ``Container``; check ``status == "ready"`` before use.
+
+        Raises:
+            TimeoutError: No terminal state is observed during the polling window.
+            httpx.HTTPStatusError: A polling request is rejected.
+            pydantic.ValidationError: A polling response is invalid.
+        """
         if timeout is not None:
             timeout_seconds = timeout
         if poll_interval is not None:
@@ -165,7 +296,7 @@ class ContainersClient(SynthBaseClient):
 
 
 class AsyncContainersClient:
-    """Async adapter over :class:`ContainersClient` (thread-offloaded)."""
+    """Async adapter over `ContainersClient` (thread-offloaded)."""
 
     def __init__(self, sync_client: ContainersClient) -> None:
         """Wrap a sync client for async call sites."""

--- a/synth_ai/sdk/pools.py
+++ b/synth_ai/sdk/pools.py
@@ -1,6 +1,49 @@
-"""Python-only container pools SDK.
+"""Container pools, tasks, rollouts, metrics, artifacts, usage, and events.
 
-Access via ``SynthClient().pools``. Nested namespaces: ``rollouts``, ``tasks``, ``metrics``, ``agent_rollouts``.
+Access this API through ``SynthClient().pools``. Prefer its task-oriented
+namespaces:
+
+* ``pools.rollouts`` for rollouts scoped to one pool.
+* ``pools.agent_rollouts`` for global rollouts.
+* ``pools.tasks`` for pool task definitions.
+* ``pools.metrics`` for pool utilization.
+
+The lower-level methods remain available on ``pools.raw``. Request and response
+bodies are backend-owned JSON objects. ``pools.rollouts.create``,
+``pools.agent_rollouts.create``, ``pools.raw.create_rollout``, and
+``pools.raw.create_global_rollout`` validate their closed set of request keys.
+Other raw methods pass backend contracts through without fabricating a second
+schema authority.
+
+Example:
+    from synth_ai import SynthClient
+
+    client = SynthClient()
+    try:
+        page = client.pools.list(limit=20)
+        for pool in page.get("items", []):
+            metrics = client.pools.metrics.get(pool["id"])
+            print(pool["id"], metrics)
+    finally:
+        client.pools.close()
+
+Expected output:
+    Expected output is one line per pool containing its stable ID and the
+    service-owned metrics object. An organization with no pools returns an
+    empty ``items`` list.
+
+Pagination:
+    ``limit`` defaults to ``100``. Pagination is backend-owned: continue only
+    when a response supplies a distinct continuation token such as
+    ``next_cursor``. The current production service may omit a continuation or
+    echo the supplied ``cursor``; stop in either case to avoid a loop.
+
+Errors:
+    The four rollout-creation entry points named above reject unsupported keys
+    locally with ``ValueError``.
+    Service failures raise ``httpx.HTTPStatusError``. Inspect
+    ``error.response.status_code`` to distinguish authentication,
+    authorization, validation, capacity, and transient service failures.
 """
 
 from __future__ import annotations
@@ -186,7 +229,53 @@ class _PoolMetricsClient:
 
 
 class ContainerPoolsClient(SynthBaseClient):
-    """Manage container pools, tasks, rollouts, and metrics."""
+    """Manage container pools, tasks, rollouts, and metrics.
+
+    Args:
+        api_key: Synth API key. Defaults to ``SYNTH_API_KEY``.
+        backend_base: Preferred API base URL override.
+        base_url: Compatibility alias for ``backend_base``.
+        timeout: Default request timeout in seconds. Defaults to ``30``.
+        timeout_seconds: Preferred timeout override. When supplied, it takes
+            precedence over ``timeout``.
+
+    Attributes:
+        rollouts: Pool-scoped rollout operations.
+        agent_rollouts: Global rollout operations.
+        tasks: Pool task operations.
+        metrics: Pool utilization reads.
+
+    Raises:
+        ValueError: The API key is missing or a rollout request contains a
+            non-canonical key.
+        httpx.HTTPStatusError: The service rejects an operation.
+
+    Example:
+        import os
+
+        from synth_ai import SynthClient
+
+        pool_id = os.environ["SYNTH_POOL_ID"]
+        task_id = os.environ["SYNTH_TASK_ID"]
+        client = SynthClient()
+        try:
+            rollout = client.pools.rollouts.create(
+                pool_id,
+                {
+                    "task_id": task_id,
+                    "messages": [
+                        {"role": "user", "content": "Solve the task."}
+                    ],
+                },
+            )
+            print(rollout["id"], rollout["status"])
+        finally:
+            client.pools.close()
+
+    Expected output:
+        Expected output contains the service-assigned rollout ID and its
+        initial lifecycle state.
+    """
 
     def __init__(
         self,
@@ -213,7 +302,19 @@ class ContainerPoolsClient(SynthBaseClient):
         return self
 
     def create_pool(self, request: dict[str, Any]) -> dict[str, Any]:
-        """Create a container pool."""
+        """Create one container pool.
+
+        Args:
+            request: Backend-owned pool definition. Use fields documented by
+                the active pool API contract.
+
+        Returns:
+            The created pool JSON object, including its service-assigned ID.
+
+        Raises:
+            httpx.HTTPStatusError: Authentication, authorization, validation,
+                conflict, quota, or service errors.
+        """
         return self._request("POST", "/v1/pools", json_body=request)
 
     def create(self, request: dict[str, Any]) -> dict[str, Any]:
@@ -227,7 +328,20 @@ class ContainerPoolsClient(SynthBaseClient):
         limit: int = 100,
         cursor: str | None = None,
     ) -> dict[str, Any]:
-        """List container pools with optional cursor pagination."""
+        """List container pools with cursor pagination.
+
+        Args:
+            state: Optional service-owned lifecycle-state filter. Defaults to
+                no state filter.
+            limit: Maximum page size. Defaults to ``100``.
+            cursor: Backend-owned continuation token. Defaults to ``None``.
+
+        Returns:
+            The backend page object. Stop if its continuation is missing or unchanged.
+
+        Raises:
+            httpx.HTTPStatusError: The request is rejected.
+        """
         params = {
             k: v
             for k, v in {"state": state, "limit": limit, "cursor": cursor}.items()
@@ -246,7 +360,18 @@ class ContainerPoolsClient(SynthBaseClient):
         return self.list_pools(state=state, limit=limit, cursor=cursor)
 
     def get_pool(self, pool_id: str) -> dict[str, Any]:
-        """Retrieve a pool by id."""
+        """Retrieve one pool by ID.
+
+        Args:
+            pool_id: Stable ID returned by ``create_pool`` or ``list_pools``.
+
+        Returns:
+            The current pool JSON object.
+
+        Raises:
+            httpx.HTTPStatusError: The pool is unavailable or the request is
+                rejected.
+        """
         return self._request("GET", f"/v1/pools/{pool_id}")
 
     def get(self, pool_id: str) -> dict[str, Any]:
@@ -310,7 +435,21 @@ class ContainerPoolsClient(SynthBaseClient):
         return self._request("DELETE", f"/v1/pools/{pool_id}/tasks/{task_id}")
 
     def create_rollout(self, pool_id: str, request: dict[str, Any]) -> dict[str, Any]:
-        """Start a rollout on a pool."""
+        """Start one rollout on a pool.
+
+        Args:
+            pool_id: Target pool ID.
+            request: Rollout request using only
+                `CANONICAL_ROLLOUT_REQUEST_KEYS`.
+
+        Returns:
+            The created rollout JSON object.
+
+        Raises:
+            ValueError: ``request`` contains a non-canonical key.
+            httpx.HTTPStatusError: The pool cannot accept the rollout or the
+                request is rejected.
+        """
         validate_pool_rollout_request(request, context="pools.create_rollout")
         return self._request("POST", f"/v1/pools/{pool_id}/rollouts", json_body=request)
 
@@ -326,7 +465,21 @@ class ContainerPoolsClient(SynthBaseClient):
         limit: int = 100,
         cursor: str | None = None,
     ) -> dict[str, Any]:
-        """List rollouts for a pool."""
+        """List rollouts for one pool.
+
+        Args:
+            pool_id: Target pool ID.
+            state: Optional service-owned lifecycle-state filter. Defaults to
+                no state filter.
+            limit: Maximum page size. Defaults to ``100``.
+            cursor: Backend-owned continuation token. Defaults to ``None``.
+
+        Returns:
+            The backend page object. Stop if its continuation is missing or unchanged.
+
+        Raises:
+            httpx.HTTPStatusError: The request is rejected.
+        """
         params = {
             k: v
             for k, v in {"state": state, "limit": limit, "cursor": cursor}.items()


### PR DESCRIPTION
Improves the generated ContainersClient and ContainerPoolsClient references, repairs keyword-only signatures in MDX output, and documents the native async Research client on dev.\n\nValidation:\n- SDK reference regenerated from source\n- docstring coverage gate previously passed (10 manifest modules)\n- final jsk review: no actionable regressions\n\nNo runtime behavior changes. No tests, Ruff, or ty were run per workspace policy.