### PR TITLE
Remove dropped SDK class sections

### DIFF
--- a/synth_ai/sdk/containers.py
+++ b/synth_ai/sdk/containers.py
@@ -120,12 +120,6 @@ class ContainersClient(SynthBaseClient):
         ValueError: The API key is missing.
         httpx.HTTPStatusError: The service rejects an operation.
         pydantic.ValidationError: A service response does not match ``Container``.
-
-    Availability:
-        Methods require a deployment that exposes ``/v1/containers``. Although
-        the SDK's bundled OpenAPI file describes those routes, the current
-        production backend directs hosted workloads through
-        ``SynthClient().pools``.
     """
 
     def __init__(

--- a/synth_ai/sdk/pools.py
+++ b/synth_ai/sdk/pools.py
@@ -249,32 +249,6 @@ class ContainerPoolsClient(SynthBaseClient):
         ValueError: The API key is missing or a rollout request contains a
             non-canonical key.
         httpx.HTTPStatusError: The service rejects an operation.
-
-    Example:
-        import os
-
-        from synth_ai import SynthClient
-
-        pool_id = os.environ["SYNTH_POOL_ID"]
-        task_id = os.environ["SYNTH_TASK_ID"]
-        client = SynthClient()
-        try:
-            rollout = client.pools.rollouts.create(
-                pool_id,
-                {
-                    "task_id": task_id,
-                    "messages": [
-                        {"role": "user", "content": "Solve the task."}
-                    ],
-                },
-            )
-            print(rollout["id"], rollout["status"])
-        finally:
-            client.pools.close()
-
-    Expected output:
-        Expected output contains the service-assigned rollout ID and its
-        initial lifecycle state.
     """
 
     def __init__(


### PR DESCRIPTION
Removes duplicate class-level documentation sections that mdxify drops. The same availability and runnable guidance remains at module level and in generated output.\n\nThis directly addresses the release-compatibility branch review finding. No runtime behavior changes.