### PR TITLE
feat(research): expose synth internal provider

### DIFF
--- a/synth_ai/core/research/_legacy/models/smr_providers.py
+++ b/synth_ai/core/research/_legacy/models/smr_providers.py
@@ -24,6 +24,7 @@ class ResourceProvider(StrEnum):
     MODAL = "modal"
     OPENAI_CHATGPT = "openai_chatgpt"
     BASETEN = "baseten"
+    SYNTH_INTERNAL = "synth_internal"
 
 
 # Deprecated alias retained one release; prefer ``ResourceProvider``.

--- a/synth_ai/core/research/_legacy/models/smr_providers.py
+++ b/synth_ai/core/research/_legacy/models/smr_providers.py
@@ -24,7 +24,6 @@ class ResourceProvider(StrEnum):
     MODAL = "modal"
     OPENAI_CHATGPT = "openai_chatgpt"
     BASETEN = "baseten"
-    SYNTH_INTERNAL = "synth_internal"
 
 
 # Deprecated alias retained one release; prefer ``ResourceProvider``.

--- a/synth_ai/core/research/contracts/swarms.py
+++ b/synth_ai/core/research/contracts/swarms.py
@@ -129,7 +129,6 @@ class ResourceProvider(StrEnum):
     MODAL = "modal"
     OPENAI_CHATGPT = "openai_chatgpt"
     BASETEN = "baseten"
-    SYNTH_INTERNAL = "synth_internal"
 
 
 class FundingSource(StrEnum):

--- a/synth_ai/core/research/contracts/swarms.py
+++ b/synth_ai/core/research/contracts/swarms.py
@@ -129,6 +129,7 @@ class ResourceProvider(StrEnum):
     MODAL = "modal"
     OPENAI_CHATGPT = "openai_chatgpt"
     BASETEN = "baseten"
+    SYNTH_INTERNAL = "synth_internal"
 
 
 class FundingSource(StrEnum):
@@ -143,6 +144,7 @@ class CredentialProvider(StrEnum):
     OPENROUTER = "openrouter"
     XAI = "xai"
     TINKER = "tinker"
+    SYNTH_INTERNAL = "synth_internal"
 
 
 class InferenceProvider(StrEnum):
@@ -152,6 +154,7 @@ class InferenceProvider(StrEnum):
     GOOGLE = "google"
     OPENROUTER = "openrouter"
     XAI = "xai"
+    SYNTH_INTERNAL = "synth_internal"
 
 
 class ToolProvider(StrEnum):


### PR DESCRIPTION
Aligns public Synth Research provider enums with backend synth_internal support across resource, credential, and inference provider contracts, including the legacy ResourceProvider compatibility surface.\n\nFocused validation: Python compilation, public enum construction probe in the evals uv environment, and git diff --check. No automated tests, Ruff, or ty run per workspace policy.