### PR TITLE
fix(research): accept min_level on run logs readout

### DIFF
--- a/synth_ai/core/research/_legacy/sdk/_run_authority_mixin.py
+++ b/synth_ai/core/research/_legacy/sdk/_run_authority_mixin.py
@@ -155,12 +155,13 @@ class ManagedResearchRunAuthorityMixin:
         *,
         limit: int | None = None,
         cursor: str | None = None,
+        min_level: str | None = None,
     ) -> dict[str, Any]:
         return _coerce_dict(
             self._request_json(
                 "GET",
                 f"/smr/projects/{project_id}/runs/{run_id}/logs",
-                params=build_query_params(limit=limit, cursor=cursor),
+                params=build_query_params(limit=limit, cursor=cursor, min_level=min_level),
             ),
             label="get_run_logs",
         )

--- a/synth_ai/core/research/_legacy/sdk/_run_authority_mixin.py
+++ b/synth_ai/core/research/_legacy/sdk/_run_authority_mixin.py
@@ -156,12 +156,15 @@ class ManagedResearchRunAuthorityMixin:
         limit: int | None = None,
         cursor: str | None = None,
         min_level: str | None = None,
+        compact: bool | None = None,
     ) -> dict[str, Any]:
         return _coerce_dict(
             self._request_json(
                 "GET",
                 f"/smr/projects/{project_id}/runs/{run_id}/logs",
-                params=build_query_params(limit=limit, cursor=cursor, min_level=min_level),
+                params=build_query_params(
+                    limit=limit, cursor=cursor, min_level=min_level, compact=compact
+                ),
             ),
             label="get_run_logs",
         )

--- a/synth_ai/core/research/readouts.py
+++ b/synth_ai/core/research/readouts.py
@@ -666,13 +666,15 @@ class ResearchRunLogsAPI(_RunReadoutBound):
         *,
         limit: int | None = None,
         cursor: str | None = None,
+        min_level: str | None = None,
     ) -> dict[str, Any]:
-        """List log records with optional cursor pagination."""
+        """List log records with optional cursor pagination and severity floor."""
         return self._handle._client.get_run_logs(
             self._handle.project_id,
             self._handle.run_id,
             limit=limit,
             cursor=cursor,
+            min_level=min_level,
         )
 
 

--- a/synth_ai/core/research/readouts.py
+++ b/synth_ai/core/research/readouts.py
@@ -667,6 +667,7 @@ class ResearchRunLogsAPI(_RunReadoutBound):
         limit: int | None = None,
         cursor: str | None = None,
         min_level: str | None = None,
+        compact: bool | None = None,
     ) -> dict[str, Any]:
         """List log records with optional cursor pagination and severity floor."""
         return self._handle._client.get_run_logs(
@@ -675,6 +676,7 @@ class ResearchRunLogsAPI(_RunReadoutBound):
             limit=limit,
             cursor=cursor,
             min_level=min_level,
+            compact=compact,
         )
 
 


### PR DESCRIPTION
swarmbench typed failure diagnostics call `runs.logs.list(min_level="error")` (evals `product/runs/swarmbench/run.py:1011`), but `ResearchRunLogsAPI.list()` only accepted `limit`/`cursor` — so whenever an SMR run failed, the diagnostics crashed with a TypeError and masked the run's actual failure reason. Found live: Luna README smoke on api-dev, run `30104121`.

The backend logs endpoint already accepts `min_level` (`app/api/v1/managed_research/projects.py`). This threads it through `ResearchRunLogsAPI.list` and the legacy `get_run_logs` query params; `build_query_params` drops it when unset, so existing calls are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)