### PR TITLE
fix(factory): refuse client maintenance launches

### DIFF
--- a/synth_ai/core/research/_legacy/sdk/client.py
+++ b/synth_ai/core/research/_legacy/sdk/client.py
@@ -921,9 +921,17 @@ def _build_project_run_payload(
         payload["primary_parent"] = normalized_primary_parent
     if effort_id and effort_id.strip():
         payload["effort_id"] = effort_id.strip()
+    # Maintenance is owned by the Factory wake-due flow. Public run-start
+    # callers must not advertise a path the backend authority rejects.
     normalized_run_kind = str(run_kind or "research").strip().lower()
-    if normalized_run_kind not in {"research", "maintenance"}:
-        raise ValueError("run_kind must be 'research' or 'maintenance'")
+    if normalized_run_kind == "maintenance":
+        raise ValueError(
+            "run_kind='maintenance' is Factory wake-due owned; "
+            "use factories.preview_wake / factories.wake_due instead of the "
+            "public run-start / launch path"
+        )
+    if normalized_run_kind != "research":
+        raise ValueError("run_kind must be 'research'")
     payload["run_kind"] = normalized_run_kind
     if idempotency_key_run_create and idempotency_key_run_create.strip():
         payload["idempotency_key_run_create"] = idempotency_key_run_create.strip()

--- a/synth_ai/core/research/_legacy/sdk/factories.py
+++ b/synth_ai/core/research/_legacy/sdk/factories.py
@@ -1127,13 +1127,15 @@ class EffortsAPI(_ClientNamespace):
         *,
         objective: str | None = None,
         **kwargs: Any,
-    ):
-        """Send a typed external signal to start maintenance on one Effort."""
-        return self.launch(
-            effort_id,
-            objective=objective,
-            run_kind="maintenance",
-            **kwargs,
+    ) -> None:
+        # Keep a migration stub so callers get a clear local refusal instead
+        # of an HTTP 400 from a forbidden client run_kind=maintenance start.
+        _ = (objective, kwargs)
+        raise ValueError(
+            f"launch_maintenance({effort_id!r}) is not supported; maintenance "
+            "is Factory wake-due owned. Use factories.preview_wake / "
+            "factories.wake_due instead of efforts.launch(..., "
+            "run_kind='maintenance')"
         )
 
 


### PR DESCRIPTION
Aligns the public Research client with backend Factory maintenance ownership.

Public run-start payload construction now refuses run_kind maintenance locally, and the legacy launch_maintenance convenience remains only as a migration stub with a clear Factory wake-due error. The implementation is applied at the current synth-ai authority path under synth_ai/core/research/_legacy/sdk; synth_ai/managed_research remains an exact compatibility re-export.

Impact: clients no longer advertise a maintenance launch path that backend authority correctly rejects.

Validation: git diff --check. Tests, Ruff, and ty were intentionally deferred because the operator requested merge-first consolidation followed by a separate validation inventory.
