### PR TITLE
fix(research): a poll loop is its own retry in swarms.wait

### DIFF
--- a/synth_ai/core/research/swarms.py
+++ b/synth_ai/core/research/swarms.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import AsyncIterator, Iterator
 
 from synth_ai.core.contracts.json_value import JsonObject, JsonValue
+from synth_ai.core.errors import SynthError
 from synth_ai.core.http.async_transport import AsyncHttpTransport
 from synth_ai.core.http.request import HttpRequest
 from synth_ai.core.http.transport import HttpTransport
@@ -468,6 +469,12 @@ class SwarmsAPI:
         timeout deadline has elapsed; otherwise sleeps `poll_interval_seconds`
         before polling again.
 
+        A retryable failure on one poll — a lost DNS lookup, a reset
+        connection, a 5xx — describes the caller's transport, not the Swarm, so
+        the loop absorbs it and polls again inside the same deadline. A poll
+        loop is its own retry; a wait with nineteen minutes left should not end
+        because one request did.
+
         Args:
             swarm_id: Swarm to wait for.
             timeout_seconds: Positive deadline in seconds checked after each
@@ -480,11 +487,22 @@ class SwarmsAPI:
         Raises:
             ValueError: If either polling parameter is not positive.
             TimeoutError: If a non-terminal poll occurs after the timeout deadline.
+            SynthError: The last retryable failure, when the deadline elapses
+                without any poll reading the Swarm. Callers deciding whether to
+                cancel durable work depend on this distinction: `TimeoutError`
+                means the Swarm was read and was not terminal, while a
+                retryable error means its state was never established.
         """
         _wait_arguments(timeout_seconds, poll_interval_seconds)
         deadline = time.monotonic() + timeout_seconds
         while True:
-            swarm = self.retrieve(swarm_id)
+            try:
+                swarm = self.retrieve(swarm_id)
+            except SynthError as error:
+                if not error.retryable or time.monotonic() >= deadline:
+                    raise
+                time.sleep(poll_interval_seconds)
+                continue
             if swarm.state.is_terminal:
                 return swarm
             if time.monotonic() >= deadline:
@@ -977,6 +995,10 @@ class AsyncSwarmsAPI:
         timeout deadline has elapsed; otherwise sleeps `poll_interval_seconds`
         before polling again.
 
+        A retryable failure on one poll — a lost DNS lookup, a reset
+        connection, a 5xx — describes the caller's transport, not the Swarm, so
+        the loop absorbs it and polls again inside the same deadline.
+
         Args:
             swarm_id: Swarm to wait for.
             timeout_seconds: Positive deadline in seconds checked after each
@@ -989,11 +1011,22 @@ class AsyncSwarmsAPI:
         Raises:
             ValueError: If either polling parameter is not positive.
             TimeoutError: If a non-terminal poll occurs after the timeout deadline.
+            SynthError: The last retryable failure, when the deadline elapses
+                without any poll reading the Swarm. Callers deciding whether to
+                cancel durable work depend on this distinction: `TimeoutError`
+                means the Swarm was read and was not terminal, while a
+                retryable error means its state was never established.
         """
         _wait_arguments(timeout_seconds, poll_interval_seconds)
         deadline = time.monotonic() + timeout_seconds
         while True:
-            swarm = await self.retrieve(swarm_id)
+            try:
+                swarm = await self.retrieve(swarm_id)
+            except SynthError as error:
+                if not error.retryable or time.monotonic() >= deadline:
+                    raise
+                await asyncio.sleep(poll_interval_seconds)
+                continue
             if swarm.state.is_terminal:
                 return swarm
             if time.monotonic() >= deadline:

--- a/tests/core_research/test_swarms_wait_transients.py
+++ b/tests/core_research/test_swarms_wait_transients.py
@@ -1,0 +1,182 @@
+"""A poll loop is its own retry: `swarms.wait` survives retryable failures.
+
+A wait with time left on its deadline must not end because one poll lost a DNS
+lookup. The distinction these tests pin matters to every caller that decides
+whether to cancel durable work from a failed wait: a bare `TimeoutError` means
+the Swarm was read and was not terminal, while a retryable error escaping the
+wait means its state was never established.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from synth_ai.core.errors import (
+    AuthorizationError,
+    RetryDirective,
+    SynthErrorCategory,
+    SynthErrorCode,
+    SynthFailure,
+    TransientServiceError,
+)
+from synth_ai.core.research.contracts.common import SwarmId
+from synth_ai.core.research.swarms import AsyncSwarmsAPI, SwarmsAPI
+
+SWARM_ID = SwarmId("11111111-1111-4111-8111-111111111111")
+
+
+def _transport_failure() -> TransientServiceError:
+    """The exact error the transport raises for a DNS or connection failure."""
+    return TransientServiceError(
+        0,
+        f"/smr/runs/{SWARM_ID}",
+        "network error (ConnectError)",
+        failure=SynthFailure(
+            code=SynthErrorCode("transport_error"),
+            category=SynthErrorCategory.TRANSIENT_SERVICE,
+            operation="retrieve_run",
+            request_id=None,
+            correlation_id=None,
+            retry=RetryDirective(retryable=True),
+            status=None,
+            detail="GET transport failure",
+        ),
+    )
+
+
+def _denial() -> AuthorizationError:
+    return AuthorizationError(
+        403,
+        f"/smr/runs/{SWARM_ID}",
+        "caller lacks authority for this run",
+        failure=SynthFailure(
+            code=SynthErrorCode("run_forbidden"),
+            category=SynthErrorCategory.AUTHORIZATION,
+            operation="retrieve_run",
+            request_id=None,
+            correlation_id=None,
+            retry=RetryDirective(retryable=False),
+            status=403,
+            detail="forbidden",
+        ),
+    )
+
+
+def _swarm(*, terminal: bool) -> Any:
+    return SimpleNamespace(state=SimpleNamespace(is_terminal=terminal))
+
+
+class _Outcomes:
+    """Replay a scripted sequence of retrieve outcomes, exceptions included."""
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, _swarm_id: Any) -> Any:
+        self.calls += 1
+        outcome = self._outcomes.pop(0) if self._outcomes else _swarm(terminal=True)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    async def async_call(self, _swarm_id: Any) -> Any:
+        return self(_swarm_id)
+
+
+def _sync_api(outcomes: _Outcomes, monkeypatch: pytest.MonkeyPatch) -> SwarmsAPI:
+    api = SwarmsAPI.__new__(SwarmsAPI)
+    monkeypatch.setattr(api, "retrieve", outcomes, raising=False)
+    return api
+
+
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "synth_ai.core.research.swarms.time.sleep", lambda seconds: slept.append(seconds)
+    )
+    return slept
+
+
+def test_wait_absorbs_a_transient_poll_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    outcomes = _Outcomes([_transport_failure(), _swarm(terminal=False), _swarm(terminal=True)])
+    slept = _no_sleep(monkeypatch)
+    api = _sync_api(outcomes, monkeypatch)
+
+    swarm = api.wait(SWARM_ID, timeout_seconds=60.0, poll_interval_seconds=2.0)
+
+    assert swarm.state.is_terminal is True
+    assert outcomes.calls == 3
+    assert slept == [2.0, 2.0]
+
+
+def test_wait_reraises_the_transient_failure_when_the_deadline_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Never reading the Swarm is not a verdict on it: the wait must not report a
+    # plain timeout, which callers read as "read it, still running".
+    outcomes = _Outcomes([_transport_failure() for _ in range(10)])
+    _no_sleep(monkeypatch)
+    api = _sync_api(outcomes, monkeypatch)
+
+    clock = iter([0.0, 0.0, 1000.0, 1000.0])
+    monkeypatch.setattr(
+        "synth_ai.core.research.swarms.time.monotonic", lambda: next(clock)
+    )
+
+    with pytest.raises(TransientServiceError):
+        api.wait(SWARM_ID, timeout_seconds=1.0, poll_interval_seconds=2.0)
+
+
+def test_wait_reraises_a_non_retryable_denial_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes = _Outcomes([_denial(), _swarm(terminal=True)])
+    _no_sleep(monkeypatch)
+    api = _sync_api(outcomes, monkeypatch)
+
+    with pytest.raises(AuthorizationError):
+        api.wait(SWARM_ID, timeout_seconds=60.0, poll_interval_seconds=2.0)
+    assert outcomes.calls == 1
+
+
+def test_wait_still_times_out_on_an_authoritative_nonterminal_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes = _Outcomes([_swarm(terminal=False) for _ in range(10)])
+    _no_sleep(monkeypatch)
+    api = _sync_api(outcomes, monkeypatch)
+
+    clock = iter([0.0, 1000.0])
+    monkeypatch.setattr(
+        "synth_ai.core.research.swarms.time.monotonic", lambda: next(clock)
+    )
+
+    with pytest.raises(TimeoutError):
+        api.wait(SWARM_ID, timeout_seconds=1.0, poll_interval_seconds=2.0)
+
+
+def test_async_wait_absorbs_a_transient_poll_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes = _Outcomes([_transport_failure(), _swarm(terminal=True)])
+    api = AsyncSwarmsAPI.__new__(AsyncSwarmsAPI)
+    monkeypatch.setattr(api, "retrieve", outcomes.async_call, raising=False)
+
+    slept: list[float] = []
+
+    async def _sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr("synth_ai.core.research.swarms.asyncio.sleep", _sleep)
+
+    swarm = asyncio.run(
+        api.wait(SWARM_ID, timeout_seconds=60.0, poll_interval_seconds=2.0)
+    )
+
+    assert swarm.state.is_terminal is True
+    assert outcomes.calls == 2
+    assert slept == [2.0]


### PR DESCRIPTION
## Why

A customer waiting on a twenty-minute research run loses the entire wait to any network interruption longer than the transport's three-attempt window (~1.5s). One DNS failure inside `swarms.wait` propagates out of a wait that still had nineteen minutes left, and the run itself is fine the whole time.

That is not hypothetical: it killed a staging BRSR proof. The caller's cleanup read the failed wait as a verdict on the run and stopped durable work that was healthy — a worker, its workspace, and the grade all gone. Every consumer polling a long run has to hand-roll this retry today, and the one that didn't lost two hours.

## What changed

`SwarmsAPI.wait` and `AsyncSwarmsAPI.wait` absorb retryable failures and poll again inside the same deadline. A poll loop is its own retry. Classification reads the SDK's own `SynthError.retryable` / `RetryDirective` — never error text.

Two outcomes stay distinguishable, which is exactly what a caller deciding whether to cancel durable work depends on:

| Escaping exception | Meaning |
| --- | --- |
| `TimeoutError` | the Swarm **was read** and was not terminal at the deadline |
| last retryable error | the Swarm's state was **never established** |

Non-retryable failures (403, contract mismatch) still raise on the first poll. The deadline contract is unchanged: `timeout_seconds` still bounds the call.

Note `wait` raises the builtin `TimeoutError` (this module does not import the typed one) — left as-is deliberately, since changing it would break `except TimeoutError` in customer code. Documented in the docstrings.

## Tests

`tests/core_research/test_swarms_wait_transients.py`, hermetic, using the real exception shapes the transport constructs:

- transient poll failure then terminal → returns the terminal Swarm, three polls, two sleeps
- transport down for the whole window → re-raises `TransientServiceError`, **not** `TimeoutError`
- non-retryable denial → raises on the first poll
- authoritative nonterminal reads past the deadline → still `TimeoutError`
- async variant absorbs a transient failure

```
uv run --group dev pytest tests -q                     # 53 passed
uv run ruff check synth_ai/core/research/swarms.py …   # clean
uv run ty check …                                      # All checks passed
```

## Related

The consumer-side fix lives in synth-laboratories/evals#201, which also stops treating a failed local poll as authority to cancel a durable run. This PR removes the need for consumers to write that retry at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)