### PR TITLE
fix(research): accept the completed run state the backend sends

### DIFF
--- a/synth_ai/core/research/contracts/swarms.py
+++ b/synth_ai/core/research/contracts/swarms.py
@@ -227,6 +227,7 @@ class SwarmState(StrEnum):
     PAUSED = "paused"
     FINALIZING = "finalizing"
     DONE = "done"
+    COMPLETED = "completed"
     PARTIAL = "partial"
     FAILED = "failed"
     STOPPED = "stopped"
@@ -237,6 +238,7 @@ class SwarmState(StrEnum):
     def is_terminal(self) -> bool:
         return self in {
             SwarmState.DONE,
+            SwarmState.COMPLETED,
             SwarmState.PARTIAL,
             SwarmState.FAILED,
             SwarmState.STOPPED,

--- a/tests/core_research/test_swarm_state_vocabulary.py
+++ b/tests/core_research/test_swarm_state_vocabulary.py
@@ -1,0 +1,48 @@
+"""The client must accept every state the deployed backend actually sends.
+
+`swarms.activity` raised `ValueError: 'completed' is not a valid SwarmState`
+against a real staging run: the backend reports `completed`, the enum did not
+have it, and the strict decode turned a healthy read into a client exception.
+An unknown state is a contract question, but a state the backend has been
+sending all along is just a missing member.
+"""
+
+from __future__ import annotations
+
+import pytest
+from synth_ai.core.research.contracts.swarms import SwarmState
+
+# Every value the Managed Research API can report for a run's public state.
+BACKEND_RUN_STATES = (
+    "queued",
+    "active",
+    "paused",
+    "finalizing",
+    "done",
+    "completed",
+    "partial",
+    "failed",
+    "stopped",
+    "canceled",
+)
+
+TERMINAL_BACKEND_STATES = frozenset(
+    {"done", "completed", "partial", "failed", "stopped", "canceled"}
+)
+
+
+@pytest.mark.parametrize("value", BACKEND_RUN_STATES)
+def test_state_decodes(value: str) -> None:
+    assert SwarmState(value).value == value
+
+
+@pytest.mark.parametrize("value", sorted(TERMINAL_BACKEND_STATES))
+def test_terminal_states_are_terminal(value: str) -> None:
+    assert SwarmState(value).is_terminal is True
+
+
+@pytest.mark.parametrize(
+    "value", sorted(set(BACKEND_RUN_STATES) - TERMINAL_BACKEND_STATES)
+)
+def test_live_states_are_not_terminal(value: str) -> None:
+    assert SwarmState(value).is_terminal is False


### PR DESCRIPTION
## Why

Released `synth-ai==0.17.0` raised this against a real staging run:

```text
swarms.activity → ValueError: 'completed' is not a valid SwarmState
```

The backend reports `completed`; `SwarmState` had no such member, so a strict decode turned a healthy read into a client exception. The two-line enum fix existed as an **unpushed local commit** (`199ca026`) in a working checkout — it never reached `dev`, so no release could carry it. This lands it with tests.

## What changed

- `SwarmState.COMPLETED = "completed"`, and it counts as terminal alongside `done`/`partial`/`failed`/`stopped`/`canceled`.
- `tests/core_research/test_swarm_state_vocabulary.py` pins the full vocabulary the API can report and which members are terminal, so a state the backend already sends cannot go missing again.

## Verification

`uv run --group dev pytest tests -q` → 97 passed. ruff clean.

## Release note

This plus #336 (`swarms.wait` surviving retryable failures) are the two customer-facing fixes sitting unreleased on `dev`. Customers on PyPI `0.17.0` still hit both. A `0.17.1` release is the remaining gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)