### PR TITLE
chore(research): run ruff format on the factory-lens surfaces

### DIFF
--- a/synth_ai/core/research/advanced_factories.py
+++ b/synth_ai/core/research/advanced_factories.py
@@ -332,13 +332,9 @@ class ResearchFactoryLensesAPI:
         request: FactoryResultEvaluationRequest,
     ) -> FactoryResultEvaluation:
         """Store one externally owned verdict, idempotent under attempt_key."""
-        return self._session.factories.lenses.record_evaluation(
-            factory_id, result_id, request
-        )
+        return self._session.factories.lenses.record_evaluation(factory_id, result_id, request)
 
-    def prefer(
-        self, factory_id: str, request: FactoryPreferenceRequest
-    ) -> FactoryPreferenceEvent:
+    def prefer(self, factory_id: str, request: FactoryPreferenceRequest) -> FactoryPreferenceEvent:
         """Append an immutable preference event beside the derived best."""
         return self._session.factories.lenses.prefer(factory_id, request)
 

--- a/synth_ai/core/research/contracts/factory_lenses.py
+++ b/synth_ai/core/research/contracts/factory_lenses.py
@@ -174,9 +174,7 @@ class FactoryEvaluationLens:
             lens_key=required_text(value, "lens_key"),
             lens_version=_required_int(value, "lens_version"),
             direction=FactoryLensDirection(required_text(value, "direction")),
-            missing_policy=FactoryLensMissingPolicy(
-                required_text(value, "missing_policy")
-            ),
+            missing_policy=FactoryLensMissingPolicy(required_text(value, "missing_policy")),
             tie_break=FactoryLensTieBreak(required_text(value, "tie_break")),
             status=required_text(value, "status"),
             created_at=required_datetime(value, "created_at"),
@@ -276,9 +274,7 @@ class FactoryResultEvaluationRequest:
         require_text(self.lens_key, field_name="lens_key")
         require_text(self.attempt_key, field_name="attempt_key")
         if self.status is FactoryEvaluationStatus.EVALUATED and self.score is None:
-            raise ValueError(
-                "evaluation_score_required: an 'evaluated' verdict must carry a score"
-            )
+            raise ValueError("evaluation_score_required: an 'evaluated' verdict must carry a score")
 
     def to_wire(self) -> JsonObject:
         value: JsonObject = {
@@ -349,9 +345,7 @@ class FactoryPreferenceRequest:
         require_text(self.idempotency_key, field_name="idempotency_key")
         require_text(self.reason, field_name="reason")
         if self.action is FactoryPreferenceAction.PREFER and not self.result_id:
-            raise ValueError(
-                "preference_result_required: a 'prefer' event must name a Result"
-            )
+            raise ValueError("preference_result_required: a 'prefer' event must name a Result")
 
     def to_wire(self) -> JsonObject:
         value: JsonObject = {

--- a/synth_ai/core/research/factories.py
+++ b/synth_ai/core/research/factories.py
@@ -906,7 +906,9 @@ class AsyncFactoryLensesAPI:
     def __init__(self, transport: AsyncHttpTransport) -> None:
         self._transport = transport
 
-    async def define(self, factory_id: FactoryId, request: FactoryLensSpec) -> FactoryEvaluationLens:
+    async def define(
+        self, factory_id: FactoryId, request: FactoryLensSpec
+    ) -> FactoryEvaluationLens:
         """Declare how this Factory compares its Results.
 
         Re-declaring an existing ``lens_key`` appends a new immutable version

--- a/synth_ai/core/research/session/factories.py
+++ b/synth_ai/core/research/session/factories.py
@@ -1157,7 +1157,6 @@ class EffortsAPI(_ClientNamespace):
         )
 
 
-
 class FactoryLensesAPI(_ClientNamespace):
     """Evaluation lenses, derived best-so-far, and human preference.
 
@@ -1198,9 +1197,7 @@ class FactoryLensesAPI(_ClientNamespace):
         steady state, not an empty result set.
         """
 
-        return FactoryBestResults.from_wire(
-            self._client.get_factory_best_results(factory_id)
-        )
+        return FactoryBestResults.from_wire(self._client.get_factory_best_results(factory_id))
 
     def record_evaluation(
         self,
@@ -1211,18 +1208,15 @@ class FactoryLensesAPI(_ClientNamespace):
         """Store one externally owned verdict, idempotent under attempt_key."""
 
         return FactoryResultEvaluation.from_wire(
-            self._client.record_factory_result_evaluation(
-                factory_id, result_id, request.to_wire()
-            )
+            self._client.record_factory_result_evaluation(factory_id, result_id, request.to_wire())
         )
 
-    def prefer(
-        self, factory_id: str, request: FactoryPreferenceRequest
-    ) -> FactoryPreferenceEvent:
+    def prefer(self, factory_id: str, request: FactoryPreferenceRequest) -> FactoryPreferenceEvent:
         """Append an immutable preference event beside the derived best."""
 
         return FactoryPreferenceEvent.from_wire(
             self._client.record_factory_result_preference(factory_id, request.to_wire())
         )
+
 
 __all__ = ["EffortsAPI", "FactoriesAPI", "FactoryResultsAPI"]

--- a/synth_ai/mcp/research/tools/factory_results.py
+++ b/synth_ai/mcp/research/tools/factory_results.py
@@ -89,9 +89,7 @@ def build_factory_result_tools(server: Any) -> list[ToolDefinition]:
                     missing_policy=FactoryLensMissingPolicy(
                         str(args.get("missing_policy") or "ineligible")
                     ),
-                    tie_break=FactoryLensTieBreak(
-                        str(args.get("tie_break") or "earliest_result")
-                    ),
+                    tie_break=FactoryLensTieBreak(str(args.get("tie_break") or "earliest_result")),
                     eligible_result_kinds=tuple(
                         FactoryResultKind(str(kind))
                         for kind in (args.get("eligible_result_kinds") or [])
@@ -145,9 +143,7 @@ def build_factory_result_tools(server: Any) -> list[ToolDefinition]:
                     FactoryPreferenceRequest(
                         idempotency_key=str(args["idempotency_key"]),
                         reason=str(args["reason"]),
-                        action=FactoryPreferenceAction(
-                            str(args.get("action") or "prefer")
-                        ),
+                        action=FactoryPreferenceAction(str(args.get("action") or "prefer")),
                         result_id=args.get("result_id"),
                         lens_key=args.get("lens_key"),
                     ),
@@ -199,8 +195,7 @@ def build_factory_result_tools(server: Any) -> list[ToolDefinition]:
                     "tie_break": {
                         "type": "string",
                         "description": (
-                            "earliest_result (default), latest_result, or "
-                            "lowest_result_id."
+                            "earliest_result (default), latest_result, or lowest_result_id."
                         ),
                     },
                     "eligible_result_kinds": {


### PR DESCRIPTION
`dev` is red on its own Lint gate. `ruff format --check` reports five files from the champion-free evaluation-lens work (`7577e46c`) as unformatted:

```text
synth_ai/core/research/advanced_factories.py
synth_ai/core/research/contracts/factory_lenses.py
synth_ai/core/research/factories.py
synth_ai/core/research/session/factories.py
synth_ai/mcp/research/tools/factory_results.py
```

Every branch cut from `dev` inherits that failure — #337 is currently blocked by it despite touching none of these files.

Formatting only, applied by `ruff format`. No behavior change; 77 tests pass and `ruff format --check` reports all 260 files formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)