### PR TITLE
fix(research): let body codecs set content type

### DIFF
--- a/synth_ai/core/auth/credentials.py
+++ b/synth_ai/core/auth/credentials.py
@@ -22,10 +22,10 @@ class ApiCredential:
             raise AuthenticationError("Synth API credential must not be empty")
 
     def authorization_headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self.value}",
-            "Content-Type": "application/json",
-        }
+        # The request body encoder owns Content-Type. A client-wide JSON header
+        # overrides httpx's multipart boundary and makes Visual uploads arrive
+        # as an empty body.
+        return {"Authorization": f"Bearer {self.value}"}
 
 
 def resolve_api_credential(api_key: str | None = None) -> ApiCredential:


### PR DESCRIPTION
SYN-3141 staging proved the client-wide application/json header suppresses httpx multipart boundaries, yielding 422 missing title/html before persistence. This keeps credentials responsible only for Authorization and lets JSON/multipart encoders author Content-Type. Validation: exact patched SDK published and retrieved the accepted A1 and A2 staging bytes; no automated tests were run under the user's explicit test scope.