### PR TITLE
refactor(research): rename Factory actor role seraph -> adjudicator

### DIFF
--- a/openapi/research-v1.json
+++ b/openapi/research-v1.json
@@ -6042,7 +6042,7 @@
         "properties": {
           "actor_subtype": {
             "$ref": "#/components/schemas/SmrActorSubtype",
-            "description": "Actor subtype. Supported values are main, engineer, researcher, artifact_builder, artifact_reviewer, task_completion, run_completion, safety, objective, seraph, gardener; valid combinations depend on actor_type."
+            "description": "Actor subtype. Supported values are main, engineer, researcher, artifact_builder, artifact_reviewer, task_completion, run_completion, safety, objective, adjudicator, gardener; valid combinations depend on actor_type."
           },
           "actor_type": {
             "$ref": "#/components/schemas/SmrActorType",
@@ -6132,7 +6132,7 @@
           "run_completion",
           "safety",
           "objective",
-          "seraph",
+          "adjudicator",
           "gardener"
         ],
         "title": "SmrActorSubtype",
@@ -12905,7 +12905,7 @@
           "run_completion",
           "safety",
           "objective",
-          "seraph",
+          "adjudicator",
           "gardener",
           "artifact_reviewer"
         ],

--- a/synth_ai/core/research/contracts/factories.py
+++ b/synth_ai/core/research/contracts/factories.py
@@ -278,11 +278,11 @@ class EffortMaintenanceRecurrencePolicy:
             for index, steward in enumerate(self.required_stewards)
         )
         invalid_stewards = sorted(
-            set(normalized_stewards).difference({"gardener", "seraph"})
+            set(normalized_stewards).difference({"gardener", "adjudicator"})
         )
         if invalid_stewards:
             raise ValueError(
-                "required_stewards must contain only gardener or seraph"
+                "required_stewards must contain only gardener or adjudicator"
             )
         object.__setattr__(self, "required_stewards", normalized_stewards)
 

--- a/synth_ai/core/research/contracts/factory_operations.py
+++ b/synth_ai/core/research/contracts/factory_operations.py
@@ -83,7 +83,7 @@ class FactoryIdeaStatus(StrEnum):
 
 class FactoryIdeaSource(StrEnum):
     HUMAN = "human"
-    SERAPH = "seraph"
+    ADJUDICATOR = "adjudicator"
     GARDENER = "gardener"
     ARCHITECT = "architect"
     WORKER = "worker"
@@ -93,7 +93,7 @@ class FactoryIdeaSource(StrEnum):
 
 class FactoryActorRole(StrEnum):
     ORCHESTRATOR = "orchestrator"
-    SERAPH = "seraph"
+    ADJUDICATOR = "adjudicator"
     GARDENER = "gardener"
     ARCHITECT = "architect"
     WORKER = "worker"
@@ -101,7 +101,7 @@ class FactoryActorRole(StrEnum):
 
 
 class FactoryActorOutputKind(StrEnum):
-    SERAPH_BRIEF = "seraph_brief"
+    ADJUDICATOR_BRIEF = "adjudicator_brief"
     GARDENER_DIGEST = "gardener_digest"
     ARCHITECT_FEED_HEALTH = "architect_feed_health"
     FAILURE_TAXONOMY = "failure_taxonomy"

--- a/synth_ai/core/research/contracts/smr_actor_models.py
+++ b/synth_ai/core/research/contracts/smr_actor_models.py
@@ -37,7 +37,7 @@ class SmrActorSubtype(StrEnum):
     RUN_COMPLETION = "run_completion"
     SAFETY = "safety"
     OBJECTIVE = "objective"
-    SERAPH = "seraph"
+    ADJUDICATOR = "adjudicator"
     GARDENER = "gardener"
 
 
@@ -51,7 +51,7 @@ class SmrReviewerSubtype(StrEnum):
     RUN_COMPLETION = "run_completion"
     SAFETY = "safety"
     OBJECTIVE = "objective"
-    SERAPH = "seraph"
+    ADJUDICATOR = "adjudicator"
     GARDENER = "gardener"
     ARTIFACT_REVIEWER = "artifact_reviewer"
 

--- a/synth_ai/core/research/contracts/smr_actor_policy_data.py
+++ b/synth_ai/core/research/contracts/smr_actor_policy_data.py
@@ -161,7 +161,7 @@ SMR_ACTOR_MODEL_POLICY: tuple[dict[str, Any], ...] = (
     },
     {
         "actor_type": "reviewer",
-        "actor_subtype": "seraph",
+        "actor_subtype": "adjudicator",
         "permitted_models": [
             "baseten/moonshotai/Kimi-K3",
             "baseten/zai-org/GLM-5.2",

--- a/synth_ai/core/research/contracts/swarms.py
+++ b/synth_ai/core/research/contracts/swarms.py
@@ -98,7 +98,7 @@ class ActorSubtype(StrEnum):
     RUN_COMPLETION = "run_completion"
     SAFETY = "safety"
     OBJECTIVE = "objective"
-    SERAPH = "seraph"
+    ADJUDICATOR = "adjudicator"
     GARDENER = "gardener"
 
 

--- a/synth_ai/core/research/schemas/smr_openapi.yaml
+++ b/synth_ai/core/research/schemas/smr_openapi.yaml
@@ -50169,7 +50169,7 @@ components:
           $ref: '#/components/schemas/SmrActorSubtype'
           description: Actor subtype. Supported values are main, engineer, researcher,
             artifact_builder, artifact_reviewer, task_completion, run_completion,
-            safety, objective, seraph, gardener; valid combinations depend on actor_type.
+            safety, objective, adjudicator, gardener; valid combinations depend on actor_type.
         agent_model:
           $ref: '#/components/schemas/SmrAgentModel'
           description: Actor-scoped agent model override. Engineer-only models such
@@ -50479,7 +50479,7 @@ components:
       - run_completion
       - safety
       - objective
-      - seraph
+      - adjudicator
       - gardener
       title: SmrActorSubtype
     SmrActorTraceArtifactRefResponse:
@@ -53992,7 +53992,7 @@ components:
 
         All fields are optional overrides merged onto the stored row before the
 
-        typed contract re-validates. For typed kinds (seraph_brief,
+        typed contract re-validates. For typed kinds (adjudicator_brief,
 
         gardener_digest) the contract-derived status stays authoritative;
 
@@ -54003,7 +54003,7 @@ components:
           type: string
           enum:
           - orchestrator
-          - seraph
+          - adjudicator
           - gardener
           - architect
           - worker
@@ -54012,9 +54012,9 @@ components:
         kind:
           type: string
           enum:
-          - seraph_brief
+          - adjudicator_brief
           - gardener_digest
-          - seraph_calibration
+          - adjudicator_calibration
           - architect_feed_health
           - failure_taxonomy
           - finding_report
@@ -54090,7 +54090,7 @@ components:
           - type: string
             enum:
             - orchestrator
-            - seraph
+            - adjudicator
             - gardener
             - architect
             - worker
@@ -54101,9 +54101,9 @@ components:
           anyOf:
           - type: string
             enum:
-            - seraph_brief
+            - adjudicator_brief
             - gardener_digest
-            - seraph_calibration
+            - adjudicator_calibration
             - architect_feed_health
             - failure_taxonomy
             - finding_report
@@ -54216,7 +54216,7 @@ components:
           type: string
           enum:
           - orchestrator
-          - seraph
+          - adjudicator
           - gardener
           - architect
           - worker
@@ -54225,9 +54225,9 @@ components:
         kind:
           type: string
           enum:
-          - seraph_brief
+          - adjudicator_brief
           - gardener_digest
-          - seraph_calibration
+          - adjudicator_calibration
           - architect_feed_health
           - failure_taxonomy
           - finding_report
@@ -54883,7 +54883,7 @@ components:
           type: string
           enum:
           - human
-          - seraph
+          - adjudicator
           - gardener
           - architect
           - worker
@@ -54961,7 +54961,7 @@ components:
           - type: string
             enum:
             - human
-            - seraph
+            - adjudicator
             - gardener
             - architect
             - worker
@@ -55059,7 +55059,7 @@ components:
           type: string
           enum:
           - human
-          - seraph
+          - adjudicator
           - gardener
           - architect
           - worker
@@ -63397,7 +63397,7 @@ components:
       - run_completion
       - safety
       - objective
-      - seraph
+      - adjudicator
       - gardener
       - artifact_reviewer
       title: SmrReviewerSubtype

--- a/synth_ai/core/research/session/factories.py
+++ b/synth_ai/core/research/session/factories.py
@@ -678,7 +678,7 @@ class FactoriesAPI(_ClientNamespace):
             self._client.patch_factory_actor_output(factory_id, actor_output_id, request)
         )
 
-    def record_seraph_brief(
+    def record_adjudicator_brief(
         self,
         factory_id: str,
         *,
@@ -695,8 +695,8 @@ class FactoriesAPI(_ClientNamespace):
     ) -> FactoryActorOutput:
         return self.create_actor_output(
             factory_id,
-            actor_role=FactoryActorRole.SERAPH,
-            kind=FactoryActorOutputKind.SERAPH_BRIEF,
+            actor_role=FactoryActorRole.ADJUDICATOR,
+            kind=FactoryActorOutputKind.ADJUDICATOR_BRIEF,
             title=title,
             summary=summary,
             status=status,

--- a/synth_ai/mcp/research/server.py
+++ b/synth_ai/mcp/research/server.py
@@ -1134,11 +1134,11 @@ class ResearchMcpServer:
                 metadata=_optional_object_arg(args, "metadata"),
             ).raw
 
-    def _tool_record_seraph_brief(self, args: JSONDict) -> Any:
+    def _tool_record_adjudicator_brief(self, args: JSONDict) -> Any:
         return self._record_named_factory_actor_output(
             args,
-            actor_role="seraph",
-            kind="seraph_brief",
+            actor_role="adjudicator",
+            kind="adjudicator_brief",
         )
 
     def _tool_record_gardener_digest(self, args: JSONDict) -> Any:

--- a/synth_ai/mcp/research/tools/factories.py
+++ b/synth_ai/mcp/research/tools/factories.py
@@ -619,7 +619,7 @@ def build_factory_tools(server: Any) -> list[ToolDefinition]:
         ToolDefinition(
             name="smr_record_factory_actor_output",
             description=(
-                "Record a typed Research Factory actor output such as a Seraph brief, "
+                "Record a typed Research Factory actor output such as an Adjudicator brief, "
                 "Gardener digest, Architect feed-health note, finding report, or "
                 "success-measurement card."
             ),
@@ -634,8 +634,11 @@ def build_factory_tools(server: Any) -> list[ToolDefinition]:
             required_scopes=WRITE_SCOPES,
         ),
         ToolDefinition(
-            name="smr_record_seraph_brief",
-            description="Record a Seraph brief: priority, scope, escalation, or decision guidance.",
+            name="smr_record_adjudicator_brief",
+            description=(
+                "Record an Adjudicator brief: priority, scope, escalation, or "
+                "decision guidance."
+            ),
             input_schema=tool_schema(
                 {
                     "factory_id": {"type": "string", "description": "Factory ID."},
@@ -644,7 +647,7 @@ def build_factory_tools(server: Any) -> list[ToolDefinition]:
                 },
                 required=["factory_id", "title"],
             ),
-            handler=server._tool_record_seraph_brief,
+            handler=server._tool_record_adjudicator_brief,
             required_scopes=WRITE_SCOPES,
         ),
         ToolDefinition(


### PR DESCRIPTION
SDK side of the `seraph` → `adjudicator` rename. Pairs with backend #1047 — the enum values are a wire contract and must land together.

`MagiMode.SERAPH` (org-level Research Intern verdict authority) **keeps the name**.

## Changed
`FactoryActorRole`, `FactoryIdeaSource`, `FactoryActorOutputKind` (`ADJUDICATOR_BRIEF = "adjudicator_brief"`), `SmrActorSubtype`, `SmrReviewerSubtype`, `ActorSubtype`, steward allow-set, `FactoriesAPI.record_seraph_brief` → `record_adjudicator_brief`, MCP tool `smr_record_seraph_brief` → `smr_record_adjudicator_brief`.

Second commit re-vendors `smr_openapi.yaml` and `openapi/research-v1.json` from backend, restoring byte-identity. That diff is rename-only: 38 changed lines, **zero** unrelated to the rename.

## Wire parity verified
Backend CHECK constraint and these enums both carry exactly `adjudicator` / `adjudicator_brief`.

⚠️ Note `scripts/check_research_openapi_contract.py` compares only operationId → (method, path); it never inspects enum values, so it would not have caught this drift. Parity rests on backend landing the identical rename.

## Not done
`specifications/sdk/research_capability_ledger.json` (7 hits) is generated and already stale independently — it points at `synth_ai/core/research/_legacy/sdk/factories.py`, a path that no longer exists. Regenerating produces a much larger diff than this rename accounts for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)