### PR TITLE
fix(research): expose FilesAPI on the Research facade

### DIFF
--- a/synth_ai/core/research/facade.py
+++ b/synth_ai/core/research/facade.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         ResearchAdvancedAPI,
         ResearchSession,
     )
+    from synth_ai.core.research.session.files import FilesAPI
 
 
 class Client:
@@ -133,6 +134,19 @@ class Client:
     def image_releases(self) -> ImageReleasesAPI:
         """Immutable customer image-release receipts and actor runtime images."""
         return self._core.image_releases
+
+    @property
+    def files(self) -> FilesAPI:
+        """Run and project file APIs, including trace-bundle run outputs.
+
+        `FilesAPI` has always existed on the session; it was simply never
+        surfaced here, so `client.research.files` raised `AttributeError: files`
+        while `session.files` worked. Callers reaching for run outputs — the
+        `trace_v5_bundle` collection a `trace_mode = "required"` eval performs
+        after a run completes — hit that gap only once the run had already
+        succeeded, turning a passing benchmark into a reported failure.
+        """
+        return self._open_session().files
 
     @property
     def projects(self) -> ResearchProjectsAPI:


### PR DESCRIPTION
`client.research.files` raised `AttributeError: files` while `session.files` worked. `FilesAPI` has always existed on `ResearchSession`; it was simply never surfaced on the facade alongside the other namespaces.

## Why it went unnoticed

Callers reaching for run outputs hit this only *after* a run had already succeeded. An eval with `trace_mode = "required"` collects the `trace_v5_bundle` once the benchmark completes, so a **passing** REB-000 dock run was reported as failed by post-run trace collection rather than by anything the candidate did:

```
job status: failed | benchmark_status: passed | exit_code: 0
named failures: reb-000-dock-grader: AttributeError:files
```

## Note for reviewers

Delegates to `_open_session().files` rather than `CoreResearchClient`, which has no `files` namespace. That means touching `.files` opens a session on first access, unlike the `_core`-backed properties. Plumbing it through `CoreResearchClient` instead would be the larger change if that lazy-connect behavior is unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)