### PR TITLE
chore(pricing): cut GPT-5.6 Luna 80% and Terra 20%

### DIFF
--- a/schemas/public_models.json
+++ b/schemas/public_models.json
@@ -32,12 +32,12 @@
       "pricing": {
         "currency": "USD",
         "unit": "token",
-        "input_usd": "0.000001",
-        "cached_input_usd": "1E-7",
-        "output_usd": "0.000006",
-        "reasoning_output_usd": "0.000006",
-        "source": "openai_gpt_5_6_preview",
-        "observed_at": "2026-07-09"
+        "input_usd": "2E-7",
+        "cached_input_usd": "2E-8",
+        "output_usd": "0.0000012",
+        "reasoning_output_usd": "0.0000012",
+        "source": "openai_api_pricing",
+        "observed_at": "2026-07-30"
       }
     },
     {
@@ -111,12 +111,12 @@
       "pricing": {
         "currency": "USD",
         "unit": "token",
-        "input_usd": "0.0000025",
-        "cached_input_usd": "2.5E-7",
-        "output_usd": "0.000015",
-        "reasoning_output_usd": "0.000015",
-        "source": "openai_gpt_5_6_preview",
-        "observed_at": "2026-07-09"
+        "input_usd": "0.000002",
+        "cached_input_usd": "2E-7",
+        "output_usd": "0.000012",
+        "reasoning_output_usd": "0.000012",
+        "source": "openai_api_pricing",
+        "observed_at": "2026-07-30"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Vendor updated `schemas/public_models.json` from backend so Luna (−80%) and Terra (−20%) match OpenAI’s 2026-07-30 API pricing.

## Test plan
- [ ] Confirm public models snapshot shows Luna `$0.20/$0.02/$1.20` and Terra `$2.00/$0.20/$12.00` per 1M
- [ ] Sol rates unchanged


Made with [Cursor](https://cursor.com)