### PR TITLE
feat(research): add actor image lifecycle client

### DIFF
--- a/synth_ai/sdk/research/contracts/__init__.py
+++ b/synth_ai/sdk/research/contracts/__init__.py
@@ -178,6 +178,7 @@ from synth_ai.sdk.research.contracts.factory_role_receipts import (
     FactoryRoleReceiptRuntimeEvidence,
 )
 from synth_ai.sdk.research.contracts.image_releases import (
+    ActorImageCapability,
     ActorRuntimeImageMaterialization,
     ActorRuntimeImageRelease,
     ActorRuntimeImageReleaseArchive,
@@ -530,6 +531,7 @@ __all__ = [
     "ActiveActorModel",
     "ActorHarness",
     "ActorImageBinding",
+    "ActorImageCapability",
     "ActorModel",
     "ActorModelAssignment",
     "ActorSubtype",

--- a/synth_ai/sdk/research/contracts/actor_images.py
+++ b/synth_ai/sdk/research/contracts/actor_images.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TypeAlias
+from uuid import UUID
 
 ACTOR_IMAGE_ROLES: tuple[str, ...] = (
     "orchestrator",
@@ -28,14 +29,21 @@ class ActorImageBinding:
     notes: str | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.release_id, str) or not self.release_id.strip():
-            raise ValueError("ActorImageBinding.release_id must be a nonempty string")
+        if not isinstance(self.release_id, str):
+            raise ValueError("ActorImageBinding.release_id must be a UUID string")
+        try:
+            release_id = str(UUID(self.release_id.strip()))
+        except (AttributeError, ValueError) as exc:
+            raise ValueError("ActorImageBinding.release_id must be a UUID string") from exc
+        object.__setattr__(self, "release_id", release_id)
         for field_name in ("reason", "notes"):
             value = getattr(self, field_name)
             if value is not None and (not isinstance(value, str) or not value.strip()):
                 raise ValueError(
                     f"ActorImageBinding.{field_name} must be a nonempty string when set"
                 )
+            if value is not None:
+                object.__setattr__(self, field_name, value.strip())
 
     def to_wire(self) -> dict[str, object]:
         payload: dict[str, object] = {"release_id": self.release_id.strip()}
@@ -60,10 +68,14 @@ class ActorImageBinding:
                 raise ValueError("actor image binding release_id must be a string")
             reason = payload.get("reason")
             notes = payload.get("notes")
+            if reason is not None and not isinstance(reason, str):
+                raise ValueError("actor image binding reason must be a string when set")
+            if notes is not None and not isinstance(notes, str):
+                raise ValueError("actor image binding notes must be a string when set")
             return cls(
                 release_id=release_id,
-                reason=reason if isinstance(reason, str) or reason is None else None,
-                notes=notes if isinstance(notes, str) or notes is None else None,
+                reason=reason,
+                notes=notes,
             )
         raise ValueError(
             "actor image binding must be an ActorImageBinding, release id string, or mapping"
@@ -83,10 +95,14 @@ def actor_image_overrides_payload(
         raise ValueError("actor_image_overrides must map actor roles to bindings")
     payload: dict[str, dict[str, object]] = {}
     for raw_role, raw_binding in overrides.items():
-        role = str(raw_role or "").strip().lower()
+        if not isinstance(raw_role, str):
+            raise ValueError("actor_image_overrides roles must be strings")
+        role = raw_role.strip().lower()
         if role not in ACTOR_IMAGE_ROLES:
             allowed = ", ".join(ACTOR_IMAGE_ROLES)
             raise ValueError(f"actor_image_overrides role must be one of: {allowed}")
+        if role in payload:
+            raise ValueError(f"actor_image_overrides repeats role: {role}")
         payload[role] = ActorImageBinding.from_wire(raw_binding).to_wire()
     return payload or None
 

--- a/synth_ai/sdk/research/contracts/factories.py
+++ b/synth_ai/sdk/research/contracts/factories.py
@@ -550,7 +550,6 @@ class FactorySpec:
             "name": self.name,
             "kind": self.kind.value,
             "status": self.state.value,
-            "result_authority_generation": self.result_authority_generation.value,
             "budget_policy": self.budget.to_wire() if self.budget is not None else {},
             "cap_policy": self.capacity.to_wire() if self.capacity is not None else {},
             "homeostasis_policy": {},
@@ -558,6 +557,11 @@ class FactorySpec:
             "authorization_policy": {},
             "metadata": dict(self.metadata),
         }
+        # Older production control planes predate this opt-in field and reject
+        # unknown keys.  Legacy is the backend default, so only transmit an
+        # explicit non-legacy authority choice.
+        if self.result_authority_generation is not FactoryResultAuthorityGeneration.LEGACY:
+            value["result_authority_generation"] = self.result_authority_generation.value
         if self.description is not None:
             value["description"] = self.description
         return value

--- a/synth_ai/sdk/research/contracts/image_releases.py
+++ b/synth_ai/sdk/research/contracts/image_releases.py
@@ -82,6 +82,26 @@ class ImageReleaseKind(StrEnum):
     CRAFTAX_SCORER = "craftax_scorer"
 
 
+class ActorImageCapability(StrEnum):
+    """Capabilities admitted by the backend actor-runtime image contract."""
+
+    CODEX_CLI = "codex_cli"
+    CRAFTAX_EVAL = "craftax_eval"
+    CRAFTER_EVAL = "crafter_eval"
+    DUNGEONGRID_EVAL = "dungeongrid_eval"
+    IMAGE_ARTIFACTS = "image_artifacts"
+    JAX_CPU = "jax_cpu"
+    MANAGED_RESEARCH_SDK = "managed_research_sdk"
+    MCP_CLIENT = "mcp_client"
+    MODAL_CLIENT = "modal_client"
+    NETHACK_EVAL = "nethack_eval"
+    NUMPY_STACK = "numpy_stack"
+    OPENCODE = "opencode"
+    OPENROUTER_CLIENT = "openrouter_client"
+    SYNTH_SDK = "synth_sdk"
+    VIDEO_ARTIFACTS = "video_artifacts"
+
+
 class RuntimeImageReleaseStatus(StrEnum):
     ACTIVE = "active"
     ARCHIVED = "archived"
@@ -147,6 +167,15 @@ def _strings(
             raise ValueError(f"{field}[{index}] has an invalid format")
         out.append(normalized)
     return tuple(out)
+
+
+def _capabilities(value: JsonValue) -> tuple[str, ...]:
+    capabilities = _strings(value, "capabilities", minimum=1)
+    allowed = frozenset(capability.value for capability in ActorImageCapability)
+    unexpected = sorted(set(capabilities) - allowed)
+    if unexpected:
+        raise ValueError(f"capabilities contain unsupported values: {unexpected!r}")
+    return capabilities
 
 
 def _datetime(value: object, field: str) -> datetime:
@@ -260,7 +289,9 @@ class CraftaxScorerImageReleaseDeclaration(_DeclarationBase):
     fixture_binary_sha256: str
 
     def __post_init__(self) -> None:
-        super().__post_init__()
+        # Explicit base dispatch is required for frozen slotted dataclasses on
+        # Python 3.12: zero-argument super() can retain the pre-slots class.
+        _DeclarationBase.__post_init__(self)
         if self.kind is not ImageReleaseKind.CRAFTAX_SCORER:
             raise ValueError("craftax scorer declaration kind must be craftax_scorer")
         object.__setattr__(
@@ -304,7 +335,8 @@ class ActorRuntimeImageReleaseDeclaration(_DeclarationBase):
     recipe_digest: str | None = None
 
     def __post_init__(self) -> None:
-        super().__post_init__()
+        # See CraftaxScorerImageReleaseDeclaration.__post_init__.
+        _DeclarationBase.__post_init__(self)
         if self.kind is not ImageReleaseKind.ACTOR_RUNTIME:
             raise ValueError("actor runtime declaration kind must be actor_runtime")
         object.__setattr__(self, "actor_role", _const(self.actor_role, "actor_role", "worker"))
@@ -313,9 +345,7 @@ class ActorRuntimeImageReleaseDeclaration(_DeclarationBase):
             "interface_mode",
             _const(self.interface_mode, "interface_mode", "synth_actor_runtime"),
         )
-        object.__setattr__(
-            self, "capabilities", _strings(list(self.capabilities), "capabilities", minimum=1)
-        )
+        object.__setattr__(self, "capabilities", _capabilities(list(self.capabilities)))
         object.__setattr__(
             self,
             "python_packages",
@@ -439,7 +469,7 @@ def declaration_from_wire(value: JsonValue) -> ImageReleaseDeclaration:
         source_commit_sha=source_commit_sha,
         actor_role=_const(payload["actor_role"], "actor_role", "worker"),
         interface_mode=_const(payload["interface_mode"], "interface_mode", "synth_actor_runtime"),
-        capabilities=_strings(payload["capabilities"], "capabilities", minimum=1),
+        capabilities=_capabilities(payload["capabilities"]),
         python_packages=_strings(payload["python_packages"], "python_packages", pattern=_PACKAGE),
         recipe_digest=optional_digest(payload.get("recipe_digest"), field="recipe_digest"),
     )
@@ -717,7 +747,7 @@ class ActorRuntimeImageMaterialization:
             selection_kind=_const(
                 payload["selection_kind"], "selection_kind", "customer_actor_runtime"
             ),
-            capabilities=_strings(payload["capabilities"], "capabilities", minimum=1),
+            capabilities=_capabilities(payload["capabilities"]),
             python_packages=_strings(
                 payload["python_packages"], "python_packages", pattern=_PACKAGE
             ),
@@ -1199,6 +1229,7 @@ __all__ = [
     "ActorRuntimeImageReleaseArchive",
     "ActorRuntimeImageReleaseDeclaration",
     "ActorRuntimeImageReleaseList",
+    "ActorImageCapability",
     "CraftaxScorerImageRelease",
     "CraftaxScorerImageReleaseDeclaration",
     "ImageRelease",

--- a/synth_ai/sdk/research/image_releases.py
+++ b/synth_ai/sdk/research/image_releases.py
@@ -5,7 +5,11 @@
 
 from __future__ import annotations
 
+import hashlib
+from pathlib import Path
 from typing import cast
+
+import httpx
 
 from synth_ai.core.contracts.json_value import JsonObject, JsonValue
 from synth_ai.core.http.async_transport import AsyncHttpTransport
@@ -79,6 +83,52 @@ def _retrieve(value: object, *, release_id: ImageReleaseId) -> ImageRelease:
     return release
 
 
+def _archive_path(
+    archive_path: str | Path,
+    *,
+    request: ImageReleaseUploadRequest,
+) -> Path:
+    """Verify the exact bytes that the backend will materialize.
+
+    The signed upload URL is intentionally the only direct-storage capability
+    used here.  Authentication for the Research API is never forwarded to the
+    object store.
+    """
+    path = Path(archive_path).expanduser().resolve()
+    if not path.is_file():
+        raise ValueError(f"image release archive is not a file: {path}")
+    if path.stat().st_size != request.declaration.archive_size_bytes:
+        raise ValueError("image release archive size does not match its declaration")
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    if digest.hexdigest() != request.declaration.archive_sha256:
+        raise ValueError("image release archive digest does not match its declaration")
+    return path
+
+
+def _upload_timeout_seconds(value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("upload_timeout_seconds must be a number")
+    timeout_seconds = float(value)
+    if not 1.0 <= timeout_seconds <= 7200.0:
+        raise ValueError("upload_timeout_seconds must be between 1 and 7200")
+    return timeout_seconds
+
+
+def _verify_finalized_upload(
+    finalized: ImageReleaseFinalize,
+    *,
+    upload: ImageReleaseUpload,
+) -> ImageReleaseFinalize:
+    if finalized.release.release_id != upload.release_id:
+        raise ValueError("image finalize response changed its release identity")
+    if finalized.upload_reconciliation.upload_id != upload.upload_id:
+        raise ValueError("image finalize response changed its upload identity")
+    return finalized
+
+
 class ImageReleasesAPI:
     """Immutable uploads plus executable actor-image materializations."""
 
@@ -115,6 +165,48 @@ class ImageReleasesAPI:
         )
         return _finalize(value, request=request)
 
+    def upload_archive(
+        self,
+        archive_path: str | Path,
+        request: ImageReleaseUploadRequest,
+        *,
+        upload_timeout_seconds: float = 1800.0,
+    ) -> ImageReleaseFinalize:
+        """Upload and materialize an exact declared OCI archive.
+
+        The local archive is validated before requesting a presigned URL.  A
+        non-2xx object-store response is terminal: finalize is never attempted
+        against bytes the SDK did not observe as successfully uploaded.
+        """
+        if not isinstance(request, ImageReleaseUploadRequest):
+            raise ValueError("request must be ImageReleaseUploadRequest")
+        path = _archive_path(archive_path, request=request)
+        timeout_seconds = _upload_timeout_seconds(upload_timeout_seconds)
+        upload = self.create_upload(request)
+        if upload.upload_required:
+            with (
+                httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client,
+                path.open("rb") as archive,
+            ):
+                response = client.put(
+                    upload.upload_url,
+                    content=archive,
+                    headers={"Content-Length": str(request.declaration.archive_size_bytes)},
+                )
+            if not response.is_success:
+                raise RuntimeError(
+                    f"image release archive upload failed with HTTP {response.status_code}"
+                )
+        return _verify_finalized_upload(
+            self.finalize(
+                ImageReleaseFinalizeRequest(
+                    upload_id=upload.upload_id,
+                    declaration=request.declaration,
+                )
+            ),
+            upload=upload,
+        )
+
     def list(self) -> ActorRuntimeImageReleaseList:
         value = self._transport.execute(
             _request(
@@ -146,6 +238,14 @@ class ImageReleasesAPI:
             )
         )
         return _retrieve(value, release_id=release_id)
+
+    def get(self, release_id: ImageReleaseId) -> ImageRelease:
+        """Retrieve one immutable image-release receipt.
+
+        ``retrieve`` remains available for callers on the earlier core-client
+        surface; ``get`` matches the lifecycle verb used by the session API.
+        """
+        return self.retrieve(release_id)
 
 
 class AsyncImageReleasesAPI:
@@ -184,6 +284,44 @@ class AsyncImageReleasesAPI:
         )
         return _finalize(value, request=request)
 
+    async def upload_archive(
+        self,
+        archive_path: str | Path,
+        request: ImageReleaseUploadRequest,
+        *,
+        upload_timeout_seconds: float = 1800.0,
+    ) -> ImageReleaseFinalize:
+        """Native-async upload and materialization of an exact OCI archive."""
+        if not isinstance(request, ImageReleaseUploadRequest):
+            raise ValueError("request must be ImageReleaseUploadRequest")
+        path = _archive_path(archive_path, request=request)
+        timeout_seconds = _upload_timeout_seconds(upload_timeout_seconds)
+        upload = await self.create_upload(request)
+        if upload.upload_required:
+            async with httpx.AsyncClient(
+                timeout=timeout_seconds,
+                follow_redirects=False,
+            ) as client:
+                with path.open("rb") as archive:
+                    response = await client.put(
+                        upload.upload_url,
+                        content=archive,
+                        headers={"Content-Length": str(request.declaration.archive_size_bytes)},
+                    )
+            if not response.is_success:
+                raise RuntimeError(
+                    f"image release archive upload failed with HTTP {response.status_code}"
+                )
+        return _verify_finalized_upload(
+            await self.finalize(
+                ImageReleaseFinalizeRequest(
+                    upload_id=upload.upload_id,
+                    declaration=request.declaration,
+                )
+            ),
+            upload=upload,
+        )
+
     async def list(self) -> ActorRuntimeImageReleaseList:
         value = await self._transport.execute(
             _request(
@@ -215,6 +353,10 @@ class AsyncImageReleasesAPI:
             )
         )
         return _retrieve(value, release_id=release_id)
+
+    async def get(self, release_id: ImageReleaseId) -> ImageRelease:
+        """Native-async peer of :meth:`ImageReleasesAPI.get`."""
+        return await self.retrieve(release_id)
 
 
 __all__ = ["AsyncImageReleasesAPI", "ImageReleasesAPI"]


### PR DESCRIPTION
## What changed

- Add typed sync and async actor-image lifecycle operations under `research.image_releases`: list, get, create upload, verified archive upload, finalize, and archive.
- Verify local OCI archive size and SHA before requesting storage upload.
- Never forward Synth API authentication to presigned object storage; reject every non-2xx upload and verify upload/release identities before returning.
- Make actor-image bindings fail closed on malformed release UUIDs, metadata, roles, and duplicate normalized roles.
- Mirror the backend actor capability allowlist.
- Fix Python 3.12 construction for frozen slotted image-release declarations.
- Preserve older production compatibility by omitting the legacy-default `result_authority_generation` field.

## Why

Customers and internal canaries need one typed SDK path to publish an actor image, obtain its immutable runtime release ID, and bind that ID to a run. Arbitrary Docker refs and ambiguous uploads must never become execution authority.

## Validation

- Ruff, formatting, and compilation passed.
- Typed wire/archive smoke checks passed.
- Targeted SDK core surface: 19 passed.

## Promotion blockers

Keep this draft until the backend PR lands in dev, a staging image materializes with `daytona_pullable=true`, and the exact release ID/digest is proven in a monitored hosted canary. The full unit command is currently blocked by pre-existing sibling-repository migration-boundary artifacts; its first four gates pass.
