### PR TITLE
chore(release): bump next dev base to 0.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synth AI SDK
 
-<!-- CI release pins: PyPI-0.18.0-orange synth-ai==0.18.0 -->
+<!-- CI release pins: PyPI-0.18.1-orange synth-ai==0.18.1 -->
 
 [![PyPI version](https://img.shields.io/pypi/v/synth-ai.svg)](https://pypi.org/project/synth-ai/)
 [![License](https://img.shields.io/pypi/l/synth-ai.svg)](https://pypi.org/project/synth-ai/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.18.0"
+version = "0.18.1"
 description = "Python SDK and CLI for Synth Managed Research and Research Factory"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2042,7 +2042,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump the next development release base from `0.18.0` to `0.18.1`
- keep both README CI pins and the editable lock entry consistent

The dev auto-publish workflow correctly refused `0.18.0.dev593` because stable `0.18.0` already exists on PyPI. Neither `0.18.1` nor the next `0.18.1.dev*` build exists.

## Verification
- README pins agree with `pyproject.toml`
- `uv build --wheel --sdist` produced 0.18.1 artifacts
- `twine check` passed for wheel and sdist
- `git diff --check`