### PR TITLE
feat(sdk): expose project metered infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-ai"
-version = "0.18.1"
+version = "0.18.2"
 description = "Python SDK and CLI for Synth Managed Research and Research Factory"
 authors = [{name = "Synth AI", email = "josh@usesynth.ai"}]
 license = "MIT"

--- a/synth_ai/sdk/research/contracts/projects.py
+++ b/synth_ai/sdk/research/contracts/projects.py
@@ -51,6 +51,7 @@ class ProjectSpec:
     notes: str | None = None
     execution_policy: JsonObject = field(default_factory=dict)
     research: JsonObject = field(default_factory=dict)
+    metered_infra: JsonObject = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         for name, value in (
@@ -78,6 +79,7 @@ class ProjectSpec:
             "timezone": self.timezone,
             "execution_policy": dict(self.execution_policy),
             "research": dict(self.research),
+            "metered_infra": dict(self.metered_infra),
         }
         for name, value in (
             ("reviewer_profile_id", self.reviewer_profile_id),

--- a/tests/test_project_spec_metered_infra.py
+++ b/tests/test_project_spec_metered_infra.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from synth_ai.sdk.research.contracts.projects import ProjectSpec
+
+
+def test_project_spec_serializes_metered_inference_contract() -> None:
+    spec = ProjectSpec(
+        name="REB hosted inference",
+        pool_id="default",
+        runtime_kind="sandbox_agent",
+        environment_kind="harbor",
+        orchestrator_profile_id="orchestrator",
+        default_worker_profile_id="worker",
+        metered_infra={
+            "inference": {
+                "enabled": True,
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "openai_compatible": True,
+            }
+        },
+    )
+
+    assert spec.to_wire()["metered_infra"] == {
+        "inference": {
+            "enabled": True,
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "openai_compatible": True,
+        }
+    }
+
+
+def test_project_spec_defaults_to_an_empty_metered_infra_contract() -> None:
+    spec = ProjectSpec(
+        name="No metered inference",
+        pool_id="default",
+        runtime_kind="sandbox_agent",
+        environment_kind="harbor",
+        orchestrator_profile_id="orchestrator",
+        default_worker_profile_id="worker",
+    )
+
+    assert spec.to_wire()["metered_infra"] == {}

--- a/uv.lock
+++ b/uv.lock
@@ -2042,7 +2042,7 @@ wheels = [
 
 [[package]]
 name = "synth-ai"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add typed `ProjectSpec.metered_infra` serialization
- preserve an explicit empty default
- bump SDK to 0.18.2

This lets callers request a backend-owned, run-scoped metered inference route without putting any provider credential in an actor or project payload.

## Verification
- `uv run --locked pytest tests/test_project_spec_metered_infra.py -q`
- `uv run --locked ruff check synth_ai/sdk/research/contracts/projects.py tests/test_project_spec_metered_infra.py`