### PR TITLE
Harden SynthTunnel contracts for long RL runs

### DIFF
--- a/openapi/synth-api-v1.yaml
+++ b/openapi/synth-api-v1.yaml
@@ -1730,7 +1730,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SynthTunnelLeaseCreateRequest'
       responses:
-        '200':
+        '201':
           description: SynthTunnel lease payload
           content:
             application/json:
@@ -1738,6 +1738,16 @@ paths:
                 $ref: '#/components/schemas/SynthTunnelLease'
 
   /api/v1/synthtunnel/leases/{lease_id}:
+    get:
+      tags: [Tunnels]
+      summary: Get SynthTunnel lease status
+      x-internal: true
+      operationId: getSynthTunnelLease
+      parameters:
+        - $ref: '#/components/parameters/LeaseId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ObjectResponse'
     delete:
       tags: [Tunnels]
       summary: Close SynthTunnel lease
@@ -1749,6 +1759,60 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ObjectResponse'
+
+  /api/v1/synthtunnel/leases/{lease_id}/token:refresh:
+    post:
+      tags: [Tunnels]
+      summary: Refresh overlapping SynthTunnel worker credentials
+      x-internal: true
+      operationId: refreshSynthTunnelWorkerToken
+      parameters:
+        - $ref: '#/components/parameters/LeaseId'
+      responses:
+        '200':
+          description: Current worker credentials covering the remaining lease
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynthTunnelWorkerCredentials'
+
+  /api/v1/synthtunnel/leases/{lease_id}/heartbeat:
+    post:
+      tags: [Tunnels]
+      summary: Extend a live SynthTunnel lease and rotate live credentials
+      x-internal: true
+      operationId: heartbeatSynthTunnelLease
+      parameters:
+        - $ref: '#/components/parameters/LeaseId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SynthTunnelHeartbeatRequest'
+      responses:
+        '200':
+          description: Extended lease and current attachment credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynthTunnelLeaseCredentials'
+
+  /api/v1/synthtunnel/leases/{lease_id}/attach:
+    post:
+      tags: [Tunnels]
+      summary: Reattach a local agent to an existing SynthTunnel lease
+      x-internal: true
+      operationId: attachSynthTunnelLease
+      parameters:
+        - $ref: '#/components/parameters/LeaseId'
+      responses:
+        '200':
+          description: Existing route and fresh attachment credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynthTunnelLeaseCredentials'
 
 components:
   securitySchemes:
@@ -2857,6 +2921,8 @@ components:
           additionalProperties: true
         requested_ttl_seconds:
           type: integer
+          minimum: 60
+          maximum: 604800
         metadata:
           type: object
           additionalProperties: true
@@ -2878,6 +2944,9 @@ components:
           type: string
         worker_token:
           type: string
+        worker_token_expires_at:
+          type: string
+          format: date-time
         expires_at:
           type: string
           format: date-time
@@ -2891,3 +2960,59 @@ components:
           type: object
           additionalProperties: true
       additionalProperties: true
+
+    SynthTunnelHeartbeatRequest:
+      type: object
+      properties:
+        extend_ttl_seconds:
+          type: integer
+          minimum: 60
+          maximum: 604800
+          default: 3600
+      additionalProperties: false
+
+    SynthTunnelWorkerCredentials:
+      type: object
+      required: [lease_id, worker_token, worker_token_expires_at, lease_expires_at]
+      properties:
+        lease_id:
+          type: string
+        worker_token:
+          type: string
+        worker_token_expires_at:
+          type: string
+          format: date-time
+        lease_expires_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+
+    SynthTunnelLeaseCredentials:
+      type: object
+      required: [lease_id, status, public_url, agent_connect, worker_token,
+        worker_token_expires_at, expires_at, limits, heartbeat]
+      properties:
+        lease_id:
+          type: string
+        status:
+          type: string
+        public_url:
+          type: string
+        agent_connect:
+          type: object
+          additionalProperties: true
+        worker_token:
+          type: string
+        worker_token_expires_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        limits:
+          type: object
+          additionalProperties: true
+        heartbeat:
+          type: object
+          additionalProperties: true
+      additionalProperties: false

--- a/schemas/smr_openapi.yaml
+++ b/schemas/smr_openapi.yaml
@@ -36277,6 +36277,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/synthtunnel/leases/{lease_id}/heartbeat:
+    post:
+      tags:
+      - synthtunnel
+      summary: Heartbeat Lease
+      operationId: heartbeat_lease_api_v1_synthtunnel_leases__lease_id__heartbeat_post
+      parameters:
+      - name: lease_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Lease Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LeaseHeartbeatRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaseCredentialsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/synthtunnel/leases/{lease_id}/attach:
+    post:
+      tags:
+      - synthtunnel
+      summary: Attach Lease
+      operationId: attach_lease_api_v1_synthtunnel_leases__lease_id__attach_post
+      parameters:
+      - name: lease_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Lease Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaseCredentialsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/optimizers/gelo-launch-promo/status:
     get:
       tags:
@@ -40400,11 +40458,16 @@ components:
         agent_token:
           type: string
           title: Agent Token
+        token_expires_at:
+          type: string
+          format: date-time
+          title: Token Expires At
       type: object
       required:
       - transport
       - url
       - agent_token
+      - token_expires_at
       title: AgentConnectInfo
     AgentSessionCreateRequest:
       properties:
@@ -42967,7 +43030,7 @@ components:
           $ref: '#/components/schemas/LocalTarget'
         requested_ttl_seconds:
           type: integer
-          maximum: 86400.0
+          maximum: 604800.0
           minimum: 60.0
           title: Requested Ttl Seconds
           default: 3600
@@ -43003,6 +43066,10 @@ components:
         worker_token:
           type: string
           title: Worker Token
+        worker_token_expires_at:
+          type: string
+          format: date-time
+          title: Worker Token Expires At
         expires_at:
           type: string
           format: date-time
@@ -43019,6 +43086,7 @@ components:
       - public_url
       - agent_connect
       - worker_token
+      - worker_token_expires_at
       - expires_at
       - limits
       - heartbeat
@@ -47496,6 +47564,46 @@ components:
       - agent_kind
       - model
       title: LaunchRoleDefaultsResponse
+    LeaseCredentialsResponse:
+      properties:
+        lease_id:
+          type: string
+          title: Lease Id
+        status:
+          type: string
+          title: Status
+        public_url:
+          type: string
+          title: Public Url
+        agent_connect:
+          $ref: '#/components/schemas/AgentConnectInfo'
+        worker_token:
+          type: string
+          title: Worker Token
+        worker_token_expires_at:
+          type: string
+          format: date-time
+          title: Worker Token Expires At
+        expires_at:
+          type: string
+          format: date-time
+          title: Expires At
+        limits:
+          $ref: '#/components/schemas/LeaseLimits'
+        heartbeat:
+          $ref: '#/components/schemas/LeaseHeartbeat'
+      type: object
+      required:
+      - lease_id
+      - status
+      - public_url
+      - agent_connect
+      - worker_token
+      - worker_token_expires_at
+      - expires_at
+      - limits
+      - heartbeat
+      title: LeaseCredentialsResponse
     LeaseHeartbeat:
       properties:
         required:
@@ -47509,6 +47617,16 @@ components:
       - required
       - recommended_interval_seconds
       title: LeaseHeartbeat
+    LeaseHeartbeatRequest:
+      properties:
+        extend_ttl_seconds:
+          type: integer
+          maximum: 604800.0
+          minimum: 60.0
+          title: Extend Ttl Seconds
+          default: 3600
+      type: object
+      title: LeaseHeartbeatRequest
     LeaseLimits:
       properties:
         max_inflight:
@@ -52058,10 +52176,20 @@ components:
         worker_token:
           type: string
           title: Worker Token
+        worker_token_expires_at:
+          type: string
+          format: date-time
+          title: Worker Token Expires At
+        lease_expires_at:
+          type: string
+          format: date-time
+          title: Lease Expires At
       type: object
       required:
       - lease_id
       - worker_token
+      - worker_token_expires_at
+      - lease_expires_at
       title: RefreshTokenResponse
     RegisterTrainedModelBody:
       properties:


### PR DESCRIPTION
## What changed

Documents the long-running SynthTunnel lease contract: durable heartbeat and attach operations, bounded multi-agent capacity, lease-aligned credentials, and retry/resume fields.

## Why

RL workloads can outlive short worker credentials and need an explicit way to recover the same public route after local reconnects.

## Impact

Backend contract validation and downstream clients can rely on stable long-run lease semantics without changing existing callers.

## Validation

- Parsed both modified OpenAPI YAML files
- `git diff --check`