### PR TITLE
fix(sdk): expose async actor reply identity

### DIFF
--- a/synth_ai/sdk/research/contracts/research_intern.py
+++ b/synth_ai/sdk/research/contracts/research_intern.py
@@ -560,6 +560,10 @@ class InternAsyncRuntime(_StrictContract):
     pending_interaction_id: str | None = None
     pending_action_id: str | None = None
     pending_actor_message_id: str | None = None
+    # A successful Manderqueue publish is not an actor reply. These identities
+    # stay projected until reconciliation observes a correlated response.
+    awaiting_actor_reply_message_id: str | None = None
+    awaiting_actor_reply_thread_id: str | None = None
     pending_instruction_count: int = Field(default=0, ge=0, le=32)
     binding: InternRuntimeBinding
     external_execution_status: InternAsyncExternalExecutionStatus
@@ -583,6 +587,11 @@ class InternAsyncRuntime(_StrictContract):
             and self.evidence_readiness is not InternAsyncEvidenceReadiness.READY
         ):
             raise ValueError("completed Async Intern requires ready evidence")
+        if self.status is InternAsyncStatus.COMPLETED and (
+            self.awaiting_actor_reply_message_id is not None
+            or self.awaiting_actor_reply_thread_id is not None
+        ):
+            raise ValueError("completed Async Intern cannot await an actor reply")
         return self
 
 

--- a/tests/test_intern_remaining_contracts.py
+++ b/tests/test_intern_remaining_contracts.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 
 from synth_ai.sdk.research.contracts.factory_operations import FactoryWakeDueRequest
 from synth_ai.sdk.research.contracts.research_intern import (
+    InternAsyncRuntime,
     InternRuntimeOutcome,
     InternSyncSession,
 )
@@ -46,3 +47,38 @@ def test_factory_wake_effort_scope_round_trips_in_signed_contract() -> None:
     wire = request.to_contract_wire()
     replay = FactoryWakeDueRequest.from_contract_wire(wire)
     assert replay.effort_ids == ("effort-a", "effort-b")
+
+
+def test_async_projection_preserves_actor_reply_wait_identity() -> None:
+    now = datetime.now(UTC).isoformat()
+    runtime = InternAsyncRuntime.from_wire(
+        {
+            "schema_version": "smr.intern-async-runtime.v1",
+            "async_runtime_id": "async-1",
+            "async_assignment_id": "async-1",
+            "cardinality": "one_per_organization",
+            "instance_kind": "organization_async_intern",
+            "research_intern_id": "intern-1",
+            "org_id": "org-1",
+            "objective": "Wait for the actor reply",
+            "status": "reconciling",
+            "state_generation": 4,
+            "last_event_sequence": 4,
+            "cycle_number": 1,
+            "plan": {},
+            "awaiting_actor_reply_message_id": "mq-1",
+            "awaiting_actor_reply_thread_id": "thread-1",
+            "pending_instruction_count": 0,
+            "binding": {},
+            "external_execution_status": "active",
+            "evidence_readiness": "pending",
+            "budget": {"maximum_concurrent_runs": 1},
+            "temporal_workflow_id": "intern-async:org-1:async-1",
+            "leave_safe": True,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+
+    assert runtime.awaiting_actor_reply_message_id == "mq-1"
+    assert runtime.awaiting_actor_reply_thread_id == "thread-1"


### PR DESCRIPTION
## Summary
- expose the Async runtime's pending actor-reply message and thread IDs in the typed SDK contract
- reject a completed runtime that still reports a pending actor reply
- cover wire parsing and completion validation

## Validation
- .............                                                            [100%]
13 passed in 0.69s (13 passed)
- All checks passed!